### PR TITLE
Feat/custom error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ incremented upon a breaking change and the patch version will be incremented for
 
 ## [Unreleased]
 ### Added
+- feat/possibility to implement custom transaction error handling ([#145](https://github.com/Ackee-Blockchain/trident/pull/145))
 - feat/support of automatically obtaining fully qualified paths of Data Accounts Custom types for `accounts_snapshots.rs` ([#141](https://github.com/Ackee-Blockchain/trident/pull/141))
 - feat/allow direct accounts manipulation and storage ([#142](https://github.com/Ackee-Blockchain/trident/pull/142))
 - feat/support of non-corresponding instruction and context names ([#130](https://github.com/Ackee-Blockchain/trident/pull/130))

--- a/crates/client/derive/fuzz_test_executor/src/lib.rs
+++ b/crates/client/derive/fuzz_test_executor/src/lib.rs
@@ -37,20 +37,29 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
                         let sig: Vec<&Keypair> = signers.iter().collect();
                         transaction.sign(&sig, client.get_last_blockhash());
 
-                        client.process_transaction(transaction)
-                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())))?;
+                        let tx_result = client.process_transaction(transaction)
+                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())));
 
-                        snaphot.capture_after(client).unwrap();
-                        let (acc_before, acc_after) = snaphot.get_snapshot()
-                            .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())))
-                            .expect("Snapshot deserialization expect"); // we want to panic if we cannot unwrap to cause a crash
+                        match tx_result {
+                            Ok(_) => {
+                                snaphot.capture_after(client).unwrap();
+                                let (acc_before, acc_after) = snaphot.get_snapshot()
+                                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())))
+                                    .expect("Snapshot deserialization expect"); // we want to panic if we cannot unwrap to cause a crash
 
-                        if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
-                            eprintln!(
-                                "CRASH DETECTED! Custom check after the {} instruction did not pass!",
-                                self.to_context_string());
-                            panic!("{}", e)
+                                if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
+                                    eprintln!(
+                                        "CRASH DETECTED! Custom check after the {} instruction did not pass!",
+                                        self.to_context_string());
+                                    panic!("{}", e)
+                                }
+                            },
+                            Err(e) => {
+                                let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
+                                ix.tx_error_handler(e, data, &mut raw_accounts)?
+                            }
                         }
+
                     }
                 }
             });

--- a/crates/client/src/fuzzer/data_builder.rs
+++ b/crates/client/src/fuzzer/data_builder.rs
@@ -80,7 +80,6 @@ where
             #[cfg(fuzzing_debug)]
             eprintln!("Currently processing: {}", fuzz_ix);
 
-            // fuzz_ix.run_fuzzer(program_id, &self.accounts, client)?;
             if fuzz_ix
                 .run_fuzzer(program_id, &self.accounts, client)
                 .is_err()
@@ -125,22 +124,40 @@ pub trait FuzzDataBuilder<T: for<'a> Arbitrary<'a>> {
     }
 }
 
+/// A trait providing methods to prepare data and accounts for the fuzzed instructions and allowing
+/// users to implement custom invariants checks and transactions error handling.
 pub trait IxOps<'info> {
+    /// The data to be passed as instruction data parameter
     type IxData;
+    /// The accounts to be passed as instruction accounts
     type IxAccounts;
+    /// The structure to which the instruction accounts will be deserialized
     type IxSnapshot;
+
+    /// Provides instruction data for the fuzzed instruction.
+    /// It is assumed that the instruction data will be based on the fuzzer input stored in the `self.data` variable.
+    /// However it is on the developer to decide and it can be also for example a hardcoded constant.
+    /// You should only avoid any non-deterministic random values to preserve reproducibility of the tests.
     fn get_data(
         &self,
         client: &mut impl FuzzClient,
         fuzz_accounts: &mut Self::IxAccounts,
     ) -> Result<Self::IxData, FuzzingError>;
 
+    /// Provides accounts required for the fuzzed instruction. The method returns a tuple of signers and account metas.
     fn get_accounts(
         &self,
         client: &mut impl FuzzClient,
         fuzz_accounts: &mut Self::IxAccounts,
     ) -> Result<(Vec<Keypair>, Vec<AccountMeta>), FuzzingError>;
 
+    /// A method to implement custom invariants checks for a given instruction. This method is called after each
+    /// successfully executed instruction and by default does nothing. You can override this behavior by providing
+    /// your own implementation. You can access the snapshots of account states before and after the transaction for comparison.
+    ///
+    /// If you want to detect a crash, you have to return a `FuzzingError` (or alternativelly panic).
+    ///
+    /// If you want to perform checks also on a failed instruction execution, you can do so using the [`tx_error_handler`](trident_client::fuzzer::data_builder::IxOps::tx_error_handler) method.
     #[allow(unused_variables)]
     fn check(
         &self,
@@ -151,11 +168,31 @@ pub trait IxOps<'info> {
         Ok(())
     }
 
+    /// A method to implement custom error handler for failed transactions.
+    ///
+    /// The fuzzer might generate a sequence of one or more instructions that are executed sequentially.
+    /// By default, if the execution of one of the instructions fails, the remaining instructions are skipped
+    /// and are not executed. This can be overriden by implementing this method and returning `Ok(())`
+    /// instead of propagating the error.
+    ///
+    /// You can also check the kind of the transaction error by inspecting the `e` parameter.
+    /// If you would like to detect a crash on a specific error, call `panic!()`.
+    ///
+    /// If your accounts are malformed and the fuzzed program is unable to deserialize it, the transaction
+    /// execution will fail. In that case also the deserialization of accounts snapshot before executing
+    /// the instruction would fail. You are provided with the raw account infos snapshots and you are free
+    /// to deserialize the accounts by yourself and therefore also handling potential errors. To deserialize
+    /// the `pre_ix_acc_infos` raw accounts to a snapshot structure, you can call:
+    ///
+    /// ```rust,ignore
+    /// self.deserialize_option(pre_ix_acc_infos)
+    /// ```
+    #[allow(unused_variables)]
     fn tx_error_handler(
         &self,
         e: FuzzClientErrorWithOrigin,
         ix_data: Self::IxData,
-        pre_ix_acc_infos: &'info [Option<AccountInfo<'info>>]
+        pre_ix_acc_infos: &'info mut [Option<AccountInfo<'info>>],
     ) -> Result<(), FuzzClientErrorWithOrigin> {
         Err(e)
     }

--- a/crates/client/src/fuzzer/snapshot.rs
+++ b/crates/client/src/fuzzer/snapshot.rs
@@ -93,6 +93,11 @@ where
         }
     }
 
+    pub fn get_raw_pre_ix_accounts(&'info mut self) -> Vec<Option<AccountInfo<'info>>> {
+        Self::set_missing_accounts_to_default(&mut self.before);
+        Self::calculate_account_info(&mut self.before, self.metas)
+    }
+
     pub fn get_snapshot(&'info mut self) -> Result<(T::Ix, T::Ix), FuzzingErrorWithOrigin> {
         // When user passes an account that is not initialized, the runtime will provide
         // a default empty account to the program. If the uninitialized account is of type


### PR DESCRIPTION
This PR introduces a way to override the transaction error handler and provide a custom implementation. 

**Context:**
The fuzzer generates a sequence of one or more instructions  that are processed/executed sequentially. 
Originally, in case of failed transaction (instruction), the fuzzer skipped the remaining instructions in the sequence and continued with a new fuzzer iteration. This has been modified unintentionally during refactoring in a way, that a failed transaction did not skip the subsequent instructions. Therefore also sequences with instructions that all fail are completely executed. 

With this PR, the default behavior was reverted so that the remaining instructions are skipped in case of transaction failure.

The default behavior can be overridden by providing a custom implementation of the `tx_error_handler` method of the `IxOps` trait. To continue to process remaining instructions in a sequence after a given instruction execution failed, it is possible to simply return an `Ok(())` result such as:
```rust
fn tx_error_handler(
        &self,
        e: FuzzClientErrorWithOrigin,
        ix_data: Self::IxData,
        pre_ix_acc_infos: &'info mut [Option<AccountInfo<'info>>],
    ) -> Result<(), FuzzClientErrorWithOrigin> {
        Ok(())
    }
```
In order to ignore the transaction errors and continue with the ix sequence execution, it is necessary to provide this implementation of `tx_error_handler` method for each instruction. One global setting might be implemented in the future if it will be necessary/useful.

Besides that, this method can be used to inspect the kinds of transaction errors. As described in the trait's docs:
```rust
    /// You can also check the kind of the transaction error by inspecting the `e` parameter.
    /// If you would like to detect a crash on a specific error, call `panic!()`.
    ///
    /// If your accounts are malformed and the fuzzed program is unable to deserialize it, the transaction
    /// execution will fail. In that case also the deserialization of accounts snapshot before executing
    /// the instruction would fail. You are provided with the raw account infos snapshots and you are free
    /// to deserialize the accounts by yourself and therefore also handling potential errors. To deserialize
    /// the `pre_ix_acc_infos` raw accounts to a snapshot structure, you can call:
    ///
    /// ```rust,ignore
    /// self.deserialize_option(pre_ix_acc_infos)
    /// ```
```

If this PR will be merged, it would make sense to also extend the web docs.

