### PR TITLE
fix/allow to process duplicate transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ incremented upon a breaking change and the patch version will be incremented for
 
 ## [Unreleased]
 ### Added
+- fix/allow to process duplicate transactions ([#147](https://github.com/Ackee-Blockchain/trident/pull/147))
 - feat/possibility to implement custom transaction error handling ([#145](https://github.com/Ackee-Blockchain/trident/pull/145))
 - feat/support of automatically obtaining fully qualified paths of Data Accounts Custom types for `accounts_snapshots.rs` ([#141](https://github.com/Ackee-Blockchain/trident/pull/141))
 - feat/allow direct accounts manipulation and storage ([#142](https://github.com/Ackee-Blockchain/trident/pull/142))

--- a/crates/client/derive/fuzz_test_executor/src/lib.rs
+++ b/crates/client/derive/fuzz_test_executor/src/lib.rs
@@ -37,29 +37,36 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
                         let sig: Vec<&Keypair> = signers.iter().collect();
                         transaction.sign(&sig, client.get_last_blockhash());
 
-                        let tx_result = client.process_transaction(transaction)
-                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())));
+                        let raw_message = transaction.message_data();
+                        let message_hash = Message::hash_raw_message(&raw_message);
 
-                        match tx_result {
-                            Ok(_) => {
-                                snaphot.capture_after(client).unwrap();
-                                let (acc_before, acc_after) = snaphot.get_snapshot()
-                                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())))
-                                    .expect("Snapshot deserialization expect"); // we want to panic if we cannot unwrap to cause a crash
+                        match sent_txs.insert(message_hash, ()) {
+                            Some(_) => eprintln!("\x1b[1;93mWarning\x1b[0m: Skipping duplicate instruction `{}`", self.to_context_string()),
+                            None => {
+                                let tx_result = client.process_transaction(transaction)
+                                .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())));
 
-                                if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
-                                    eprintln!(
-                                        "CRASH DETECTED! Custom check after the {} instruction did not pass!",
-                                        self.to_context_string());
-                                    panic!("{}", e)
+                                match tx_result {
+                                    Ok(_) => {
+                                        snaphot.capture_after(client).unwrap();
+                                        let (acc_before, acc_after) = snaphot.get_snapshot()
+                                            .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())))
+                                            .expect("Snapshot deserialization expect"); // we want to panic if we cannot unwrap to cause a crash
+
+                                        if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
+                                            eprintln!(
+                                                "\x1b[31mCRASH DETECTED!\x1b[0m Custom check after the {} instruction did not pass!",
+                                                self.to_context_string());
+                                            panic!("{}", e)
+                                        }
+                                    },
+                                    Err(e) => {
+                                        let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
+                                        ix.tx_error_handler(e, data, &mut raw_accounts)?
+                                    }
                                 }
-                            },
-                            Err(e) => {
-                                let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
-                                ix.tx_error_handler(e, data, &mut raw_accounts)?
                             }
                         }
-
                     }
                 }
             });
@@ -71,6 +78,7 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
                        program_id: Pubkey,
                        accounts: &RefCell<FuzzAccounts>,
                        client: &mut impl FuzzClient,
+                       sent_txs: &mut HashMap<Hash, ()>,
                    ) -> core::result::Result<(), FuzzClientErrorWithOrigin> {
                            match self {
                                #(#display_match_arms)*

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -153,7 +153,7 @@ impl Commander {
         // arguments so we need to parse the variable content.
         let hfuzz_run_args = std::env::var("HFUZZ_RUN_ARGS").unwrap_or_default();
 
-        let fuzz_args = config.get_fuzz_args(hfuzz_run_args);
+        let fuzz_args = config.get_honggfuzz_args(hfuzz_run_args);
 
         // let cargo_target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_default();
 
@@ -181,10 +181,20 @@ impl Commander {
             }
         }
 
+        let mut rustflags = if config.fuzz.allow_duplicate_txs {
+            "--cfg allow_duplicate_txs "
+        } else {
+            ""
+        }
+        .to_string();
+
+        rustflags.push_str(&std::env::var("RUSTFLAGS").unwrap_or_default());
+
         let mut child = Command::new("cargo")
             .env("HFUZZ_RUN_ARGS", fuzz_args)
             .env("CARGO_TARGET_DIR", cargo_target_dir)
             .env("HFUZZ_WORKSPACE", hfuzz_workspace)
+            .env("RUSTFLAGS", rustflags)
             .arg("hfuzz")
             .arg("run")
             .arg(target)
@@ -226,12 +236,22 @@ impl Commander {
         let hfuzz_workspace = std::env::var("HFUZZ_WORKSPACE")
             .unwrap_or_else(|_| config.get_env_arg("HFUZZ_WORKSPACE"));
 
-        let fuzz_args = config.get_fuzz_args(hfuzz_run_args);
+        let fuzz_args = config.get_honggfuzz_args(hfuzz_run_args);
+
+        let mut rustflags = if config.fuzz.allow_duplicate_txs {
+            "--cfg allow_duplicate_txs "
+        } else {
+            ""
+        }
+        .to_string();
+
+        rustflags.push_str(&std::env::var("RUSTFLAGS").unwrap_or_default());
 
         let mut child = Command::new("cargo")
             .env("HFUZZ_RUN_ARGS", fuzz_args)
             .env("CARGO_TARGET_DIR", cargo_target_dir)
             .env("HFUZZ_WORKSPACE", hfuzz_workspace)
+            .env("RUSTFLAGS", rustflags)
             .arg("hfuzz")
             .arg("run")
             .arg(target)
@@ -266,9 +286,19 @@ impl Commander {
         let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
             .unwrap_or_else(|_| config.get_env_arg("CARGO_TARGET_DIR"));
 
+        let mut rustflags = if config.fuzz.allow_duplicate_txs {
+            "--cfg allow_duplicate_txs "
+        } else {
+            ""
+        }
+        .to_string();
+
+        rustflags.push_str(&std::env::var("RUSTFLAGS").unwrap_or_default());
+
         // using exec rather than spawn and replacing current process to avoid unflushed terminal output after ctrl+c signal
         std::process::Command::new("cargo")
             .env("CARGO_TARGET_DIR", cargo_target_dir)
+            .env("RUSTFLAGS", rustflags)
             .arg("hfuzz")
             .arg("run-debug")
             .arg(target)

--- a/crates/client/src/fuzzer/data_builder.rs
+++ b/crates/client/src/fuzzer/data_builder.rs
@@ -9,6 +9,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::transaction::VersionedTransaction;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Display;
 
@@ -69,19 +70,21 @@ where
 
         #[cfg(fuzzing_debug)]
         {
-            eprintln!("Instructions sequence:");
+            eprintln!("\x1b[34mInstructions sequence\x1b[0m:");
             for ix in self.iter() {
                 eprintln!("{}", ix);
             }
             eprintln!("------ End of Instructions sequence ------ ");
         }
 
+        let mut sent_txs: HashMap<Hash, ()> = HashMap::new();
+
         for fuzz_ix in &mut self.iter() {
             #[cfg(fuzzing_debug)]
-            eprintln!("Currently processing: {}", fuzz_ix);
+            eprintln!("\x1b[34mCurrently processing\x1b[0m: {}", fuzz_ix);
 
             if fuzz_ix
-                .run_fuzzer(program_id, &self.accounts, client)
+                .run_fuzzer(program_id, &self.accounts, client, &mut sent_txs)
                 .is_err()
             {
                 // for now skip following instructions in case of error and move to the next fuzz iteration
@@ -98,6 +101,7 @@ pub trait FuzzTestExecutor<T> {
         program_id: Pubkey,
         accounts: &RefCell<T>,
         client: &mut impl FuzzClient,
+        sent_txs: &mut HashMap<Hash, ()>,
     ) -> core::result::Result<(), FuzzClientErrorWithOrigin>;
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -47,6 +47,7 @@ pub mod fuzzing {
     pub use super::fuzzer::snapshot::Snapshot;
     pub use super::fuzzer::*;
     pub use std::cell::RefCell;
+    pub use std::collections::HashMap;
     pub use trident_derive_displayix::DisplayIx;
     pub use trident_derive_fuzz_deserialize::FuzzDeserialize;
     pub use trident_derive_fuzz_test_executor::FuzzTestExecutor;

--- a/crates/client/src/templates/Trident.toml.tmpl
+++ b/crates/client/src/templates/Trident.toml.tmpl
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
+++ b/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
@@ -1,147 +1,145 @@
+#![feature(prelude_import)]
+#[prelude_import]
+use std::prelude::rust_2018::*;
+#[macro_use]
+extern crate std;
 use trident_client::FuzzTestExecutor;
 pub enum FuzzInstruction {
     InitVesting(InitVesting),
     WithdrawUnlocked(WithdrawUnlocked),
 }
 impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
-    fn run_fuzzer(
-        &self,
-        program_id: Pubkey,
-        accounts: &RefCell<FuzzAccounts>,
-        client: &mut impl FuzzClient,
-    ) -> core::result::Result<(), FuzzClientErrorWithOrigin> {
+    fn run_fuzzer(&self, program_id: Pubkey, accounts: &RefCell<FuzzAccounts>,
+        client: &mut impl FuzzClient, sent_txs: &mut HashMap<Hash, ()>)
+        -> core::result::Result<(), FuzzClientErrorWithOrigin> {
         match self {
             FuzzInstruction::InitVesting(ix) => {
-                let (mut signers, metas) = ix
-                    .get_accounts(client, &mut accounts.borrow_mut())
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    })
-                    .expect("Accounts calculation expect");
+                let (mut signers, metas) =
+                    ix.get_accounts(client,
+                                &mut accounts.borrow_mut()).map_err(|e|
+                                e.with_origin(Origin::Instruction(self.to_context_string()))).expect("Accounts calculation expect");
                 let mut snaphot = Snapshot::new(&metas, ix);
                 snaphot.capture_before(client).unwrap();
-                let data = ix
-                    .get_data(client, &mut accounts.borrow_mut())
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    })
-                    .expect("Data calculation expect");
-                let ixx = Instruction {
-                    program_id,
-                    accounts: metas.clone(),
-                    data: data.data(),
-                };
-                let mut transaction = Transaction::new_with_payer(
-                    &[ixx],
-                    Some(&client.payer().pubkey()),
-                );
+                let data =
+                    ix.get_data(client,
+                                &mut accounts.borrow_mut()).map_err(|e|
+                                e.with_origin(Origin::Instruction(self.to_context_string()))).expect("Data calculation expect");
+                let ixx =
+                    Instruction {
+                        program_id,
+                        accounts: metas.clone(),
+                        data: data.data(),
+                    };
+                let mut transaction =
+                    Transaction::new_with_payer(&[ixx],
+                        Some(&client.payer().pubkey()));
                 signers.push(client.payer().clone());
                 let sig: Vec<&Keypair> = signers.iter().collect();
                 transaction.sign(&sig, client.get_last_blockhash());
-                let tx_result = client
-                    .process_transaction(transaction)
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    });
-                match tx_result {
-                    Ok(_) => {
-                        snaphot.capture_after(client).unwrap();
-                        let (acc_before, acc_after) = snaphot
-                            .get_snapshot()
-                            .map_err(|e| {
-                                e.with_origin(Origin::Instruction(self.to_context_string()))
-                            })
-                            .expect("Snapshot deserialization expect");
-                        if let Err(e)
-                            = ix
-                                .check(acc_before, acc_after, data)
-                                .map_err(|e| {
-                                    e.with_origin(Origin::Instruction(self.to_context_string()))
-                                })
-                        {
-                            {
-                                ::std::io::_eprint(
-                                    format_args!(
-                                        "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
-                                        self.to_context_string(),
-                                    ),
-                                );
-                            };
-                            {
-                                ::core::panicking::panic_display(&e);
+                let duplicate_tx =
+                    if false {
+                            None
+                        } else {
+                           let message_hash = transaction.message().hash();
+                           sent_txs.insert(message_hash, ())
+                       };
+                match duplicate_tx {
+                    Some(_) => {
+                        ::std::io::_eprint(format_args!("\u{{1b}}[1;93mWarning\u{{1b}}[0m: Skipping duplicate instruction `{0}`\n",
+                                self.to_context_string()));
+                    }
+                    None => {
+                        let tx_result =
+                            client.process_transaction(transaction).map_err(|e|
+                                    e.with_origin(Origin::Instruction(self.to_context_string())));
+                        match tx_result {
+                            Ok(_) => {
+                                snaphot.capture_after(client).unwrap();
+                                let (acc_before, acc_after) =
+                                    snaphot.get_snapshot().map_err(|e|
+                                                e.with_origin(Origin::Instruction(self.to_context_string()))).expect("Snapshot deserialization expect");
+                                if let Err(e) =
+                                            ix.check(acc_before, acc_after,
+                                                    data).map_err(|e|
+                                                    e.with_origin(Origin::Instruction(self.to_context_string())))
+                                        {
+                                        {
+                                            ::std::io::_eprint(format_args!("\u{{1b}}[31mCRASH DETECTED!\u{{1b}}[0m Custom check after the {0} instruction did not pass!\n",
+                                                    self.to_context_string()));
+                                        };
+                                        { ::core::panicking::panic_display(&e); }
+                                    }
+                            }
+                            Err(e) => {
+                                let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
+                                ix.tx_error_handler(e, data, &mut raw_accounts)?
                             }
                         }
-                    }
-                    Err(e) => {
-                        let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
-                        ix.tx_error_handler(e, data, &mut raw_accounts)?
                     }
                 }
             }
             FuzzInstruction::WithdrawUnlocked(ix) => {
-                let (mut signers, metas) = ix
-                    .get_accounts(client, &mut accounts.borrow_mut())
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    })
-                    .expect("Accounts calculation expect");
+                let (mut signers, metas) =
+                    ix.get_accounts(client,
+                                &mut accounts.borrow_mut()).map_err(|e|
+                                e.with_origin(Origin::Instruction(self.to_context_string()))).expect("Accounts calculation expect");
                 let mut snaphot = Snapshot::new(&metas, ix);
                 snaphot.capture_before(client).unwrap();
-                let data = ix
-                    .get_data(client, &mut accounts.borrow_mut())
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    })
-                    .expect("Data calculation expect");
-                let ixx = Instruction {
-                    program_id,
-                    accounts: metas.clone(),
-                    data: data.data(),
-                };
-                let mut transaction = Transaction::new_with_payer(
-                    &[ixx],
-                    Some(&client.payer().pubkey()),
-                );
+                let data =
+                    ix.get_data(client,
+                                &mut accounts.borrow_mut()).map_err(|e|
+                                e.with_origin(Origin::Instruction(self.to_context_string()))).expect("Data calculation expect");
+                let ixx =
+                    Instruction {
+                        program_id,
+                        accounts: metas.clone(),
+                        data: data.data(),
+                    };
+                let mut transaction =
+                    Transaction::new_with_payer(&[ixx],
+                        Some(&client.payer().pubkey()));
                 signers.push(client.payer().clone());
                 let sig: Vec<&Keypair> = signers.iter().collect();
                 transaction.sign(&sig, client.get_last_blockhash());
-                let tx_result = client
-                    .process_transaction(transaction)
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    });
-                match tx_result {
-                    Ok(_) => {
-                        snaphot.capture_after(client).unwrap();
-                        let (acc_before, acc_after) = snaphot
-                            .get_snapshot()
-                            .map_err(|e| {
-                                e.with_origin(Origin::Instruction(self.to_context_string()))
-                            })
-                            .expect("Snapshot deserialization expect");
-                        if let Err(e)
-                            = ix
-                                .check(acc_before, acc_after, data)
-                                .map_err(|e| {
-                                    e.with_origin(Origin::Instruction(self.to_context_string()))
-                                })
-                        {
-                            {
-                                ::std::io::_eprint(
-                                    format_args!(
-                                        "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
-                                        self.to_context_string(),
-                                    ),
-                                );
-                            };
-                            {
-                                ::core::panicking::panic_display(&e);
+                let duplicate_tx =
+                    if false {
+                            None
+                        } else {
+                           let message_hash = transaction.message().hash();
+                           sent_txs.insert(message_hash, ())
+                       };
+                match duplicate_tx {
+                    Some(_) => {
+                        ::std::io::_eprint(format_args!("\u{{1b}}[1;93mWarning\u{{1b}}[0m: Skipping duplicate instruction `{0}`\n",
+                                self.to_context_string()));
+                    }
+                    None => {
+                        let tx_result =
+                            client.process_transaction(transaction).map_err(|e|
+                                    e.with_origin(Origin::Instruction(self.to_context_string())));
+                        match tx_result {
+                            Ok(_) => {
+                                snaphot.capture_after(client).unwrap();
+                                let (acc_before, acc_after) =
+                                    snaphot.get_snapshot().map_err(|e|
+                                                e.with_origin(Origin::Instruction(self.to_context_string()))).expect("Snapshot deserialization expect");
+                                if let Err(e) =
+                                            ix.check(acc_before, acc_after,
+                                                    data).map_err(|e|
+                                                    e.with_origin(Origin::Instruction(self.to_context_string())))
+                                        {
+                                        {
+                                            ::std::io::_eprint(format_args!("\u{{1b}}[31mCRASH DETECTED!\u{{1b}}[0m Custom check after the {0} instruction did not pass!\n",
+                                                    self.to_context_string()));
+                                        };
+                                        { ::core::panicking::panic_display(&e); }
+                                    }
+                            }
+                            Err(e) => {
+                                let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
+                                ix.tx_error_handler(e, data, &mut raw_accounts)?
                             }
                         }
-                    }
-                    Err(e) => {
-                        let mut raw_accounts = snaphot.get_raw_pre_ix_accounts();
-                        ix.tx_error_handler(e, data, &mut raw_accounts)?
                     }
                 }
             }

--- a/examples/fuzz-tests/arbitrary-custom-types-4/Trident.toml
+++ b/examples/fuzz-tests/arbitrary-custom-types-4/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/arbitrary-custom-types-4/Trident.toml
+++ b/examples/fuzz-tests/arbitrary-custom-types-4/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/fuzz-tests/arbitrary-limit-inputs-5/Trident.toml
+++ b/examples/fuzz-tests/arbitrary-limit-inputs-5/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/arbitrary-limit-inputs-5/Trident.toml
+++ b/examples/fuzz-tests/arbitrary-limit-inputs-5/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/fuzz-tests/hello_world/Trident.toml
+++ b/examples/fuzz-tests/hello_world/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/hello_world/Trident.toml
+++ b/examples/fuzz-tests/hello_world/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/fuzz-tests/incorrect-integer-arithmetic-3/Trident.toml
+++ b/examples/fuzz-tests/incorrect-integer-arithmetic-3/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/incorrect-integer-arithmetic-3/Trident.toml
+++ b/examples/fuzz-tests/incorrect-integer-arithmetic-3/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/fuzz-tests/incorrect-ix-sequence-1/Trident.toml
+++ b/examples/fuzz-tests/incorrect-ix-sequence-1/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/incorrect-ix-sequence-1/Trident.toml
+++ b/examples/fuzz-tests/incorrect-ix-sequence-1/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/fuzz-tests/unauthorized-access-2/Trident.toml
+++ b/examples/fuzz-tests/unauthorized-access-2/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/unauthorized-access-2/Trident.toml
+++ b/examples/fuzz-tests/unauthorized-access-2/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/fuzz-tests/unchecked-arithmetic-0/Trident.toml
+++ b/examples/fuzz-tests/unchecked-arithmetic-0/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/fuzz-tests/unchecked-arithmetic-0/Trident.toml
+++ b/examples/fuzz-tests/unchecked-arithmetic-0/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/integration-tests/escrow/Trident.toml
+++ b/examples/integration-tests/escrow/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/integration-tests/escrow/Trident.toml
+++ b/examples/integration-tests/escrow/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false

--- a/examples/integration-tests/turnstile/Trident.toml
+++ b/examples/integration-tests/turnstile/Trident.toml
@@ -2,7 +2,7 @@
 validator_startup_timeout = 15000
 
 
-[fuzz]
+[honggfuzz]
 # Timeout in seconds (default: 10)
 timeout = 10
 # Number of fuzzing iterations (default: 0 [no limit])

--- a/examples/integration-tests/turnstile/Trident.toml
+++ b/examples/integration-tests/turnstile/Trident.toml
@@ -32,3 +32,7 @@ run_time = 0
 max_file_size = 1048576
 # Save all test-cases (not only the unique ones) by appending the current time-stamp to the filenames (default: false)
 save_all = false
+
+[fuzz]
+# Allow processing of duplicate transactions. Setting to true might speed up fuzzing but can cause false positive crashes (default: false)
+allow_duplicate_txs = false


### PR DESCRIPTION
This PR resolves an issues with duplicate transactions. If the fuzzer generates two or more consecutive transactions with the same data and accounts (and therefore the same hash) that are executed successfully, than only the first transaction is processed and the remaining transactions are rejected by the runtime. However the process_transaction function returns an `Ok(())` result even if the transaction was rejected. This is a problem, because then also the `check` method is executed and depending on the implementation does not have to pass. 

For example if checking that a transfer from an account was done correctly (and that the balance changed), the check will pass after the first transaction but will fail after the remaining ones, because the transaction will not be processed at all and the balance will stay the same.

One option to fix this issue would be to artificially warp to higher slot number so that the runtime does not spot the duplicate. However modifying the slot number might eventually interfere with some protocols relying on it. Therefore another solution was implemented where it is verified before processing a transaction that a transaction with the same hash was not processed before. If yes, the duplicate transaction is skipped and a warning is emitted in logs. The duplicates detection is done via hash of the transaction that is store in a HashMap. If the hash is present, than it is a duplicate. It was not possible to use for example the `unique` method from the `itertools` crate, because this method required `Eq` and `Hash` trait bounds. This would "color" all the instruction structures and also disallow usage of floating data types as these do not have `Eq` implementations.

Also a possibility to override this default behavior was implemented. To allow duplicate transactions, it is possible to set the parameter `allow_duplicate_txs` in Trident.toml to true. This might slightly increase the performance of fuzzing but you risk to encounter false positive crash findings.

As a side effect, the `fuzz` group in Trident.toml configuration file was renamed to `honggfuzz` and a new group `fuzz` was created to setup internal fuzzer parameters.