### PR TITLE
⚡️ Add feature to initialize trident with Macro/File (for Snapshots) option based on preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 incremented upon a breaking change and the patch version will be incremented for features.
 
 ## [dev] - Unreleased
+- feat/ add option to initialize Trident with Macro/File (for Snapshots) option based on preference ([179](https://github.com/Ackee-Blockchain/trident/pull/179))
 - del/remove localnet subcommand ([178](https://github.com/Ackee-Blockchain/trident/pull/178))
 - feat/create AccountsSnapshots derive macro for Snapshots creation ([#177](https://github.com/Ackee-Blockchain/trident/pull/177))
 - del/remove unnecessary fuzzing feature as trident is mainly fuzzer ([#176](https://github.com/Ackee-Blockchain/trident/pull/176))

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -11,7 +11,7 @@ mod test;
 pub use test::test;
 
 mod init;
-pub use init::{init, TestsType};
+pub use init::{init, SnapshotsType, TestsType};
 
 mod clean;
 pub use clean::clean;

--- a/crates/cli/src/command/build.rs
+++ b/crates/cli/src/command/build.rs
@@ -22,6 +22,6 @@ pub async fn build(root: Option<String>) {
             }
         }
     };
-    let mut generator: TestGenerator = TestGenerator::new_with_root(root);
+    let mut generator: TestGenerator = TestGenerator::new_with_root(root, false);
     generator.build().await?;
 }

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -6,6 +6,8 @@ use trident_client::___private::{Commander, TestGenerator};
 
 use crate::_discover;
 
+use super::SnapshotsType;
+
 pub const TRIDENT_TOML: &str = "Trident.toml";
 
 #[derive(Subcommand)]
@@ -27,7 +29,10 @@ pub enum FuzzCommand {
         crash_file_path: String,
     },
     /// Add new fuzz test. Explicit fuzz test name is not yet supported. Implicit name is fuzz_ID, where ID is automatically derived.
-    Add,
+    Add {
+        #[clap(default_value = "macro")]
+        snapshots_type: SnapshotsType,
+    },
 }
 
 #[throws]
@@ -64,10 +69,13 @@ pub async fn fuzz(root: Option<String>, subcmd: FuzzCommand) {
             commander.run_fuzzer_debug(target, crash_file_path).await?;
         }
 
-        FuzzCommand::Add => {
+        FuzzCommand::Add { snapshots_type } => {
             // generate generator with root so that we do not need to again
             // look for root within the generator
-            let mut generator = TestGenerator::new_with_root(root);
+            let mut generator = match snapshots_type {
+                SnapshotsType::Macro => TestGenerator::new_with_root(root, false),
+                SnapshotsType::File => TestGenerator::new_with_root(root, true),
+            };
             generator.add_fuzz_test().await?;
         }
     };

--- a/crates/cli/src/command/init.rs
+++ b/crates/cli/src/command/init.rs
@@ -13,9 +13,14 @@ pub enum TestsType {
     Fuzz,
     Poc,
 }
+#[derive(ValueEnum, Clone)]
+pub enum SnapshotsType {
+    Macro,
+    File,
+}
 
 #[throws]
-pub async fn init(tests_type: TestsType) {
+pub async fn init(tests_type: TestsType, snapshots_type: SnapshotsType) {
     // look for Anchor.toml
     let root = if let Some(r) = _discover(ANCHOR_TOML)? {
         r
@@ -23,7 +28,10 @@ pub async fn init(tests_type: TestsType) {
         bail!("It does not seem that Anchor is initialized because the Anchor.toml file was not found in any parent directory!");
     };
 
-    let mut generator: TestGenerator = TestGenerator::new_with_root(root);
+    let mut generator: TestGenerator = match snapshots_type {
+        SnapshotsType::Macro => TestGenerator::new_with_root(root, false),
+        SnapshotsType::File => TestGenerator::new_with_root(root, true),
+    };
 
     match tests_type {
         TestsType::Poc => {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use command::TestsType;
+use command::{SnapshotsType, TestsType};
 use fehler::throws;
 
 // subcommand functions to call and nested subcommands
@@ -48,8 +48,11 @@ enum Command {
     /// Initialize test environment
     Init {
         /// Specifies the types of tests for which the frameworks should be initialized.
-        #[clap(default_value = "both")]
+        #[clap(default_value = "fuzz")]
         tests_type: TestsType,
+        /// Specifies type of Accounts Snapshots, i.e used derive macro or generated file
+        #[clap(default_value = "macro")]
+        snapshots_type: SnapshotsType,
     },
     /// Removes target contents except for KeyPair and removes hfuzz_target folder
     Clean,
@@ -64,7 +67,10 @@ pub async fn start() {
         Command::KeyPair { subcmd } => command::keypair(subcmd)?,
         Command::Test { root } => command::test(root).await?,
         Command::Fuzz { root, subcmd } => command::fuzz(root, subcmd).await?,
-        Command::Init { tests_type } => command::init(tests_type).await?,
+        Command::Init {
+            tests_type,
+            snapshots_type,
+        } => command::init(tests_type, snapshots_type).await?,
         Command::Clean => command::clean().await?,
     }
 }

--- a/crates/client/src/source_code_generators/fuzzer_generator.rs
+++ b/crates/client/src/source_code_generators/fuzzer_generator.rs
@@ -214,7 +214,7 @@ pub fn generate_source_code(programs_data: &[ProgramData]) -> String {
             let fuzzer_module: syn::ItemMod = parse_quote! {
                 pub mod #fuzz_instructions_module_name {
                     use trident_client::fuzzing::*;
-                    use crate::accounts_snapshots::*;
+                    // use crate::accounts_snapshots::*;
 
                     #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
                     pub enum FuzzInstruction {

--- a/crates/client/src/templates/trident-tests/test_fuzz.rs
+++ b/crates/client/src/templates/trident-tests/test_fuzz.rs
@@ -1,5 +1,4 @@
 use trident_client::fuzzing::*;
-mod accounts_snapshots;
 mod fuzz_instructions;
 
 const PROGRAM_NAME: &str = "###PROGRAM_NAME###";

--- a/crates/client/src/templates/trident-tests/test_fuzz.rs
+++ b/crates/client/src/templates/trident-tests/test_fuzz.rs
@@ -1,6 +1,10 @@
 use trident_client::fuzzing::*;
 mod fuzz_instructions;
 
+// TODO: In case of using file extension for AccountsSnapshots
+// uncomment the line below
+// mod accounts_snapshots;
+
 const PROGRAM_NAME: &str = "###PROGRAM_NAME###";
 
 struct MyFuzzData;

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -120,10 +120,11 @@ pub struct TestGenerator {
     pub programs_data: Vec<ProgramData>,
     pub packages: Vec<Package>,
     pub use_tokens: Vec<ItemUse>,
+    pub with_snapshot_file: bool,
 }
 impl Default for TestGenerator {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -133,12 +134,13 @@ impl TestGenerator {
     /// # Returns
     ///
     /// A new `TestGenerator` instance.
-    pub fn new() -> Self {
+    pub fn new(with_snapshot_file: bool) -> Self {
         Self {
             root: Path::new("../../").to_path_buf(),
             programs_data: Vec::default(),
             packages: Vec::default(),
             use_tokens: Vec::default(),
+            with_snapshot_file,
         }
     }
     /// Creates a new instance of `TestGenerator` with a specified root directory.
@@ -150,12 +152,13 @@ impl TestGenerator {
     /// # Returns
     ///
     /// A new `TestGenerator` instance with the specified root directory.
-    pub fn new_with_root(root: String) -> Self {
+    pub fn new_with_root(root: String, with_snapshot_file: bool) -> Self {
         Self {
             root: Path::new(&root).to_path_buf(),
             programs_data: Vec::default(),
             packages: Vec::default(),
             use_tokens: Vec::default(),
+            with_snapshot_file,
         }
     }
     /// Generates both proof of concept (POC) and fuzz tests along with the necessary setup.
@@ -420,17 +423,6 @@ impl TestGenerator {
     /// If not present add fuzz_tests into the workspace virtual manifest as member
     #[throws]
     pub async fn add_new_fuzz_test(&self) {
-        let program_name = if !&self.programs_data.is_empty() {
-            &self
-                .programs_data
-                .first()
-                .unwrap()
-                .program_idl
-                .name
-                .snake_case
-        } else {
-            throw!(Error::NoProgramsFound)
-        };
         let fuzz_dir_path =
             construct_path!(self.root, TESTS_WORKSPACE_DIRECTORY, FUZZ_TEST_DIRECTORY);
         let fuzz_tests_manifest_path = construct_path!(fuzz_dir_path, CARGO_TOML);
@@ -473,39 +465,17 @@ impl TestGenerator {
 
         self.create_directory(&new_fuzz_test_dir).await?;
 
-        let fuzz_test_path = new_fuzz_test_dir.join(FUZZ_TEST);
-
-        let fuzz_test_content = load_template!("/src/templates/trident-tests/test_fuzz.rs");
-
-        let use_entry = format!("use {}::entry;\n", program_name);
-        let use_instructions = format!("use {}::ID as PROGRAM_ID;\n", program_name);
-        let use_fuzz_instructions = format!(
-            "use fuzz_instructions::{}_fuzz_instructions::FuzzInstruction;\n",
-            program_name
-        );
-        let template =
-            format!("{use_entry}{use_instructions}{use_fuzz_instructions}{fuzz_test_content}");
-        let fuzz_test_content = template.replace("###PROGRAM_NAME###", program_name);
-
-        self.create_file(&fuzz_test_path, &fuzz_test_content)
-            .await?;
+        // create fuzz file
+        self.initialize_fuzz(&new_fuzz_test_dir).await?;
 
         // create fuzz instructions file
-        let fuzz_instructions_path = new_fuzz_test_dir.join(FUZZ_INSTRUCTIONS_FILE_NAME);
-        let program_fuzzer = fuzzer_generator::generate_source_code(&self.programs_data);
-        let program_fuzzer = Commander::format_program_code(&program_fuzzer).await?;
-
-        self.create_file(&fuzz_instructions_path, &program_fuzzer)
+        self.initialize_fuzz_instructions(&new_fuzz_test_dir)
             .await?;
 
-        // // create accounts_snapshots file
-        let accounts_snapshots_path = new_fuzz_test_dir.join(ACCOUNTS_SNAPSHOTS_FILE_NAME);
-        let fuzzer_snapshots = snapshot_generator::generate_snapshots_code(&self.programs_data)
-            .map_err(Error::ReadProgramCodeFailed)?;
-        let fuzzer_snapshots = Commander::format_program_code(&fuzzer_snapshots).await?;
-
-        self.create_file(&accounts_snapshots_path, &fuzzer_snapshots)
-            .await?;
+        // create accounts_snapshots file
+        if self.with_snapshot_file {
+            self.initialize_fuzz_snapshots(&new_fuzz_test_dir).await?;
+        }
 
         let cargo_toml_content =
             load_template!("/src/templates/trident-tests/Cargo_fuzz.toml.tmpl");
@@ -522,6 +492,58 @@ impl TestGenerator {
             "{TESTS_WORKSPACE_DIRECTORY}/{FUZZ_TEST_DIRECTORY}",
         ))
         .await?;
+    }
+
+    #[throws]
+    pub async fn initialize_fuzz(&self, new_fuzz_test_dir: &Path) {
+        let program_name = if !&self.programs_data.is_empty() {
+            &self
+                .programs_data
+                .first()
+                .unwrap()
+                .program_idl
+                .name
+                .snake_case
+        } else {
+            throw!(Error::NoProgramsFound)
+        };
+        let fuzz_test_path = new_fuzz_test_dir.join(FUZZ_TEST);
+
+        let fuzz_test_content = load_template!("/src/templates/trident-tests/test_fuzz.rs");
+
+        let use_entry = format!("use {}::entry;\n", program_name);
+        let use_instructions = format!("use {}::ID as PROGRAM_ID;\n", program_name);
+        let use_fuzz_instructions = format!(
+            "use fuzz_instructions::{}_fuzz_instructions::FuzzInstruction;\n",
+            program_name
+        );
+        let template =
+            format!("{use_entry}{use_instructions}{use_fuzz_instructions}{fuzz_test_content}");
+        let fuzz_test_content = template.replace("###PROGRAM_NAME###", program_name);
+
+        self.create_file(&fuzz_test_path, &fuzz_test_content)
+            .await?;
+    }
+
+    #[throws]
+    pub async fn initialize_fuzz_instructions(&self, new_fuzz_test_dir: &Path) {
+        let fuzz_instructions_path = new_fuzz_test_dir.join(FUZZ_INSTRUCTIONS_FILE_NAME);
+        let program_fuzzer = fuzzer_generator::generate_source_code(&self.programs_data);
+        let program_fuzzer = Commander::format_program_code(&program_fuzzer).await?;
+
+        self.create_file(&fuzz_instructions_path, &program_fuzzer)
+            .await?;
+    }
+
+    #[throws]
+    pub async fn initialize_fuzz_snapshots(&self, new_fuzz_test_dir: &Path) {
+        let accounts_snapshots_path = new_fuzz_test_dir.join(ACCOUNTS_SNAPSHOTS_FILE_NAME);
+        let fuzzer_snapshots = snapshot_generator::generate_snapshots_code(&self.programs_data)
+            .map_err(Error::ReadProgramCodeFailed)?;
+        let fuzzer_snapshots = Commander::format_program_code(&fuzzer_snapshots).await?;
+
+        self.create_file(&accounts_snapshots_path, &fuzzer_snapshots)
+            .await?;
     }
 
     /// Add/Update .program_client

--- a/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
@@ -1,5 +1,4 @@
 pub mod fuzz_example3_fuzz_instructions {
-    use crate::accounts_snapshots::*;
     use trident_client::fuzzing::*;
     #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {

--- a/crates/fuzz/src/trident_accounts_struct.rs
+++ b/crates/fuzz/src/trident_accounts_struct.rs
@@ -714,7 +714,7 @@ fn generate(accs: &TridentAccountsStruct) -> proc_macro2::TokenStream {
     });
 
     quote! {
-        #[cfg(feature = "trident-fuzzing")]
+        // #[cfg(feature = "trident-fuzzing")]
         pub mod #module_name{
             #[cfg(target_os = "solana")]
             compile_error!("Do not use fuzzing with Production Code");

--- a/examples/fuzz-tests/arbitrary-custom-types-4/Cargo.lock
+++ b/examples/fuzz-tests/arbitrary-custom-types-4/Cargo.lock
@@ -267,19 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-spl"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
-dependencies = [
- "anchor-lang",
- "solana-program",
- "spl-associated-token-account",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
-]
-
-[[package]]
 name = "anchor-syn"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1120,15 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2795,15 +2791,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -2818,18 +2805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4061,8 +4036,8 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
@@ -4780,7 +4755,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5085,8 +5060,8 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5257,8 +5232,8 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5346,20 +5321,6 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
@@ -5370,21 +5331,6 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
  "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
 ]
 
 [[package]]
@@ -5404,28 +5350,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum 0.7.2",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod",
- "spl-token 4.0.0",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.3.0",
- "spl-type-length-value",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d697fac19fd74ff472dfcc13f0b442dd71403178ce1de7b5d16f83a33561c059"
@@ -5440,10 +5364,10 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror",
 ]
@@ -5477,22 +5401,6 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution 0.4.0",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aabdb7c471566f6ddcee724beb8618449ea24b399e58d464d6b5bc7db550259"
@@ -5503,7 +5411,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution",
  "spl-type-length-value",
 ]
 
@@ -6090,7 +5998,6 @@ version = "0.6.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
- "anchor-spl",
  "anchor-syn",
  "anyhow",
  "arbitrary",
@@ -6120,16 +6027,27 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-associated-token-account",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",
  "toml",
+ "trident-derive-accounts-snapshots",
  "trident-derive-displayix",
  "trident-derive-fuzz-deserialize",
  "trident-derive-fuzz-test-executor",
  "trident-fuzz",
  "trident-test",
+]
+
+[[package]]
+name = "trident-derive-accounts-snapshots"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "trident-fuzz",
 ]
 
 [[package]]
@@ -6166,6 +6084,7 @@ dependencies = [
  "anchor-lang",
  "anchor-syn",
  "arbitrary",
+ "convert_case",
  "heck 0.4.1",
  "prettytable",
  "proc-macro2",
@@ -6177,7 +6096,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",

--- a/examples/fuzz-tests/arbitrary-limit-inputs-5/Cargo.lock
+++ b/examples/fuzz-tests/arbitrary-limit-inputs-5/Cargo.lock
@@ -6283,7 +6283,6 @@ version = "0.6.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
- "anchor-spl",
  "anchor-syn",
  "anyhow",
  "arbitrary",
@@ -6312,7 +6311,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-transaction-status",
- "spl-associated-token-account 3.0.2",
+ "spl-associated-token-account 2.3.0",
  "spl-token",
  "syn 1.0.109",
  "thiserror",

--- a/examples/fuzz-tests/arbitrary-limit-inputs-5/programs/arbitrary-limit-inputs-5/Cargo.toml
+++ b/examples/fuzz-tests/arbitrary-limit-inputs-5/programs/arbitrary-limit-inputs-5/Cargo.toml
@@ -9,15 +9,14 @@ crate-type = ["cdylib", "lib"]
 name = "arbitrary_limit_inputs_5"
 
 [features]
-default = ["trident-fuzzing"]
+default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
-trident-fuzzing = ["trident-client"]
 
 [dependencies]
 anchor-lang = "0.30.1"
 anchor-spl = "0.30.1"
-trident-client = { path = "../../../../../crates/client", optional = true }
+trident-client = { path = "../../../../../crates/client" }

--- a/examples/fuzz-tests/hello_world/Cargo.lock
+++ b/examples/fuzz-tests/hello_world/Cargo.lock
@@ -267,19 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-spl"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
-dependencies = [
- "anchor-lang",
- "solana-program",
- "spl-associated-token-account",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
-]
-
-[[package]]
 name = "anchor-syn"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1113,15 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2795,15 +2791,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -2818,18 +2805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4061,8 +4036,8 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
@@ -4780,7 +4755,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5085,8 +5060,8 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5257,8 +5232,8 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5346,20 +5321,6 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
@@ -5370,21 +5331,6 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
  "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
 ]
 
 [[package]]
@@ -5404,28 +5350,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum 0.7.2",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod",
- "spl-token 4.0.0",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.3.0",
- "spl-type-length-value",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d697fac19fd74ff472dfcc13f0b442dd71403178ce1de7b5d16f83a33561c059"
@@ -5440,10 +5364,10 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror",
 ]
@@ -5477,22 +5401,6 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution 0.4.0",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aabdb7c471566f6ddcee724beb8618449ea24b399e58d464d6b5bc7db550259"
@@ -5503,7 +5411,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution",
  "spl-type-length-value",
 ]
 
@@ -6090,7 +5998,6 @@ version = "0.6.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
- "anchor-spl",
  "anchor-syn",
  "anyhow",
  "arbitrary",
@@ -6120,16 +6027,27 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-associated-token-account",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",
  "toml",
+ "trident-derive-accounts-snapshots",
  "trident-derive-displayix",
  "trident-derive-fuzz-deserialize",
  "trident-derive-fuzz-test-executor",
  "trident-fuzz",
  "trident-test",
+]
+
+[[package]]
+name = "trident-derive-accounts-snapshots"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "trident-fuzz",
 ]
 
 [[package]]
@@ -6166,6 +6084,7 @@ dependencies = [
  "anchor-lang",
  "anchor-syn",
  "arbitrary",
+ "convert_case",
  "heck 0.4.1",
  "prettytable",
  "proc-macro2",
@@ -6177,7 +6096,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",

--- a/examples/fuzz-tests/incorrect-integer-arithmetic-3/Cargo.lock
+++ b/examples/fuzz-tests/incorrect-integer-arithmetic-3/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
  "anchor-lang",
  "solana-program",
  "spl-associated-token-account",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-2022 0.9.0",
 ]
 
@@ -1126,6 +1126,15 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2797,15 +2806,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -2820,18 +2820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4063,7 +4051,7 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-2022 1.0.0",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
@@ -5087,7 +5075,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-2022 1.0.0",
  "thiserror",
 ]
@@ -5259,7 +5247,7 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-2022 1.0.0",
  "thiserror",
 ]
@@ -5376,21 +5364,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
@@ -5419,7 +5392,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface 0.3.0",
  "spl-type-length-value",
@@ -5442,7 +5415,7 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface 0.4.1",
@@ -6092,7 +6065,6 @@ version = "0.6.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
- "anchor-spl",
  "anchor-syn",
  "anyhow",
  "arbitrary",
@@ -6122,16 +6094,27 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-associated-token-account",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",
  "toml",
+ "trident-derive-accounts-snapshots",
  "trident-derive-displayix",
  "trident-derive-fuzz-deserialize",
  "trident-derive-fuzz-test-executor",
  "trident-fuzz",
  "trident-test",
+]
+
+[[package]]
+name = "trident-derive-accounts-snapshots"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "trident-fuzz",
 ]
 
 [[package]]
@@ -6168,6 +6151,7 @@ dependencies = [
  "anchor-lang",
  "anchor-syn",
  "arbitrary",
+ "convert_case",
  "heck 0.4.1",
  "prettytable",
  "proc-macro2",
@@ -6179,7 +6163,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",

--- a/examples/fuzz-tests/incorrect-ix-sequence-1/Cargo.lock
+++ b/examples/fuzz-tests/incorrect-ix-sequence-1/Cargo.lock
@@ -267,19 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-spl"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
-dependencies = [
- "anchor-lang",
- "solana-program",
- "spl-associated-token-account",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
-]
-
-[[package]]
 name = "anchor-syn"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1113,15 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2795,15 +2791,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -2818,18 +2805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4061,8 +4036,8 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
@@ -4780,7 +4755,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5085,8 +5060,8 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5257,8 +5232,8 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5346,20 +5321,6 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
@@ -5370,21 +5331,6 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
  "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
 ]
 
 [[package]]
@@ -5404,28 +5350,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum 0.7.2",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod",
- "spl-token 4.0.0",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.3.0",
- "spl-type-length-value",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d697fac19fd74ff472dfcc13f0b442dd71403178ce1de7b5d16f83a33561c059"
@@ -5440,10 +5364,10 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror",
 ]
@@ -5477,22 +5401,6 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution 0.4.0",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aabdb7c471566f6ddcee724beb8618449ea24b399e58d464d6b5bc7db550259"
@@ -5503,7 +5411,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution",
  "spl-type-length-value",
 ]
 
@@ -6090,7 +5998,6 @@ version = "0.6.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
- "anchor-spl",
  "anchor-syn",
  "anyhow",
  "arbitrary",
@@ -6120,16 +6027,27 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-associated-token-account",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",
  "toml",
+ "trident-derive-accounts-snapshots",
  "trident-derive-displayix",
  "trident-derive-fuzz-deserialize",
  "trident-derive-fuzz-test-executor",
  "trident-fuzz",
  "trident-test",
+]
+
+[[package]]
+name = "trident-derive-accounts-snapshots"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "trident-fuzz",
 ]
 
 [[package]]
@@ -6166,6 +6084,7 @@ dependencies = [
  "anchor-lang",
  "anchor-syn",
  "arbitrary",
+ "convert_case",
  "heck 0.4.1",
  "prettytable",
  "proc-macro2",
@@ -6177,7 +6096,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",

--- a/examples/fuzz-tests/unauthorized-access-2/Cargo.lock
+++ b/examples/fuzz-tests/unauthorized-access-2/Cargo.lock
@@ -267,19 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-spl"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
-dependencies = [
- "anchor-lang",
- "solana-program",
- "spl-associated-token-account",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
-]
-
-[[package]]
 name = "anchor-syn"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1113,15 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2788,15 +2784,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -2811,18 +2798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4054,8 +4029,8 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
@@ -4773,7 +4748,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5078,8 +5053,8 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5250,8 +5225,8 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5339,20 +5314,6 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f335787add7fa711819f9e7c573f8145a5358a709446fe2d24bf2a88117c90"
@@ -5363,21 +5324,6 @@ dependencies = [
  "spl-pod",
  "spl-program-error",
  "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
 ]
 
 [[package]]
@@ -5397,28 +5343,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum 0.7.2",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod",
- "spl-token 4.0.0",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.3.0",
- "spl-type-length-value",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d697fac19fd74ff472dfcc13f0b442dd71403178ce1de7b5d16f83a33561c059"
@@ -5433,10 +5357,10 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror",
 ]
@@ -5470,22 +5394,6 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution 0.4.0",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aabdb7c471566f6ddcee724beb8618449ea24b399e58d464d6b5bc7db550259"
@@ -5496,7 +5404,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
- "spl-tlv-account-resolution 0.5.2",
+ "spl-tlv-account-resolution",
  "spl-type-length-value",
 ]
 
@@ -6083,7 +5991,6 @@ version = "0.6.0"
 dependencies = [
  "anchor-client",
  "anchor-lang",
- "anchor-spl",
  "anchor-syn",
  "anyhow",
  "arbitrary",
@@ -6113,16 +6020,27 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "spl-associated-token-account",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",
  "toml",
+ "trident-derive-accounts-snapshots",
  "trident-derive-displayix",
  "trident-derive-fuzz-deserialize",
  "trident-derive-fuzz-test-executor",
  "trident-fuzz",
  "trident-test",
+]
+
+[[package]]
+name = "trident-derive-accounts-snapshots"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "trident-fuzz",
 ]
 
 [[package]]
@@ -6159,6 +6077,7 @@ dependencies = [
  "anchor-lang",
  "anchor-syn",
  "arbitrary",
+ "convert_case",
  "heck 0.4.1",
  "prettytable",
  "proc-macro2",
@@ -6170,7 +6089,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-sdk",
- "spl-token 3.5.0",
+ "spl-token",
  "syn 1.0.109",
  "thiserror",
  "tokio",


### PR DESCRIPTION
This PR adds functionality such that it is possible to decide during the `trident init` command if the user wants to fuzz with AccountsSnapshots macro or using accounts_snapshots.rs file.

In case of `macro` the user needs to include trident-client in his program and derive AccountsSnapshots for every context manually, then he needs to include these derived implementations in the fuzz_instructions.rs.

In case of `file` it is required to include accounts_snapshots.rs implementation within the fuzz_instructions.rs file.

