### PR TITLE
:bug: updating gitignore by adding a new line #186

### DIFF
--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -701,7 +701,7 @@ impl TestGenerator {
             let file = OpenOptions::new().append(true).open(gitignore_path);
 
             if let Ok(mut file) = file {
-                writeln!(file, "{}", ignored_path)?;
+                writeln!(file, "\n{}", ignored_path)?;
                 println!("{FINISH} [{GIT_IGNORE}] update with [{ignored_path}]");
             }
         } else {

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -698,10 +698,20 @@ impl TestGenerator {
                     return;
                 }
             }
+            // Check if the file ends with a newline
+            let mut file = File::open(&gitignore_path)?;
+            let mut buf = [0; 1];
+            file.seek(io::SeekFrom::End(-1))?;
+            file.read_exact(&mut buf)?;
+
             let file = OpenOptions::new().append(true).open(gitignore_path);
 
             if let Ok(mut file) = file {
-                writeln!(file, "\n{}", ignored_path)?;
+                if buf[0] == b'\n' {
+                    writeln!(file, "{}", ignored_path)?;
+                } else {
+                    writeln!(file, "\n{}", ignored_path)?;
+                }
                 println!("{FINISH} [{GIT_IGNORE}] update with [{ignored_path}]");
             }
         } else {


### PR DESCRIPTION

A small but important change to the ``update_gitignore`` function in the ``TestGenerator`` struct.

Modified the ``writeln!`` macro call in the ``update_gitignore`` function to add the changes in a new line.