### PR TITLE
✨ Add possibility to add account to the genesis from base64 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ incremented upon a breaking change and the patch version will be incremented for
 ## [dev] - Unreleased
 
 **Changed**
+- feat/ option to add account into Fuzz Test environment with base64 data ([197](https://github.com/Ackee-Blockchain/trident/pull/197))
 - impr/ instead of parsing source code and creating our IDL, read anchor IDL ([196](https://github.com/Ackee-Blockchain/trident/pull/196))
 
 ## [0.7.0] - 2024-08-14

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -41,6 +41,7 @@ pub mod fuzzing {
     pub use trident_fuzz::*;
 
     pub use solana_program_test::processor;
+    pub use trident_fuzz::program_test_client_blocking::FuzzingAccountBase64;
     pub use trident_fuzz::program_test_client_blocking::FuzzingProgram;
     pub use trident_fuzz::program_test_client_blocking::ProgramEntry;
 

--- a/crates/client/src/source_code_generators/test_fuzz_generator.rs
+++ b/crates/client/src/source_code_generators/test_fuzz_generator.rs
@@ -58,7 +58,7 @@ pub fn generate_source_code(idl_instructions: &[Idl]) -> String {
 
             #(#fuzzing_programs)*
 
-            let mut client = ProgramTestClientBlocking::new(&#programs_array).unwrap();
+            let mut client = ProgramTestClientBlocking::new(&#programs_array,&[]).unwrap();
 
             #run_with_runtime
 

--- a/crates/client/tests/expected_source_codes/expected_test_fuzz.rs
+++ b/crates/client/tests/expected_source_codes/expected_test_fuzz.rs
@@ -23,7 +23,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
         processor!(convert_entry!(entry_dummy_example)),
     );
 
-    let mut client = ProgramTestClientBlocking::new(&[fuzzing_program_dummy_example]).unwrap();
+    let mut client = ProgramTestClientBlocking::new(&[fuzzing_program_dummy_example], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_DUMMY_EXAMPLE, &mut client);
 }

--- a/examples/fuzz-tests/arbitrary-custom-types-4/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/arbitrary-custom-types-4/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -31,7 +31,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_arbitrary_custom_types_4]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_arbitrary_custom_types_4], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_ARBITRARY_CUSTOM_TYPES_4, &mut client);
 }

--- a/examples/fuzz-tests/arbitrary-limit-inputs-5/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/arbitrary-limit-inputs-5/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -38,7 +38,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_arbitrary_limit_inputs_5]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_arbitrary_limit_inputs_5], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_ARBITRARY_LIMIT_INPUTS_5, &mut client);
 }

--- a/examples/fuzz-tests/cpi-metaplex-7/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/cpi-metaplex-7/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -37,7 +37,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     let metaplex = FuzzingProgram::new("metaplex-token-metadata", &mpl_token_metadata::ID, None);
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_cpi_metaplex_7, metaplex]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_cpi_metaplex_7, metaplex], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_CPI_METAPLEX_7, &mut client);
 }

--- a/examples/fuzz-tests/hello_world/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/hello_world/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -16,22 +16,19 @@ struct MyFuzzData;
 impl FuzzDataBuilder<FuzzInstruction> for MyFuzzData {}
 
 fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: FuzzData<T, U>) {
-
     let fuzzing_program_hello_world = FuzzingProgram::new(
         PROGRAM_NAME_HELLO_WORLD,
         &PROGRAM_ID_HELLO_WORLD,
         processor!(convert_entry!(entry_hello_world)),
     );
 
-    let mut client = ProgramTestClientBlocking::new(&[fuzzing_program_hello_world]).unwrap();
+    let mut client = ProgramTestClientBlocking::new(&[fuzzing_program_hello_world], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_HELLO_WORLD, &mut client);
 }
 
 fn main() {
-
     loop {
-
         fuzz_trident ! (fuzz_ix : FuzzInstruction , | fuzz_data : MyFuzzData | { fuzz_iteration (fuzz_data) ; });
     }
 }

--- a/examples/fuzz-tests/incorrect-integer-arithmetic-3/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/incorrect-integer-arithmetic-3/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -30,7 +30,8 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_incorrect_integer_arithmetic_3]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_incorrect_integer_arithmetic_3], &[])
+            .unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_INCORRECT_INTEGER_ARITHMETIC_3, &mut client);
 }

--- a/examples/fuzz-tests/incorrect-ix-sequence-1/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/incorrect-ix-sequence-1/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -29,7 +29,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_incorrect_ix_sequence_1]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_incorrect_ix_sequence_1], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_INCORRECT_IX_SEQUENCE_1, &mut client);
 }

--- a/examples/fuzz-tests/simple-cpi-6/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/simple-cpi-6/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -33,7 +33,8 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_callee, fuzzing_program_caller]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_callee, fuzzing_program_caller], &[])
+            .unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_CALLER, &mut client);
 }

--- a/examples/fuzz-tests/unauthorized-access-2/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/unauthorized-access-2/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -30,7 +30,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_unauthorized_access_2]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_unauthorized_access_2], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_UNAUTHORIZED_ACCESS_2, &mut client);
 }

--- a/examples/fuzz-tests/unchecked-arithmetic-0/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
+++ b/examples/fuzz-tests/unchecked-arithmetic-0/trident-tests/fuzz_tests/fuzz_0/test_fuzz.rs
@@ -37,7 +37,7 @@ fn fuzz_iteration<T: FuzzTestExecutor<U> + std::fmt::Display, U>(fuzz_data: Fuzz
     );
 
     let mut client =
-        ProgramTestClientBlocking::new(&[fuzzing_program_unchecked_arithmetic_0]).unwrap();
+        ProgramTestClientBlocking::new(&[fuzzing_program_unchecked_arithmetic_0], &[]).unwrap();
 
     let _ = fuzz_data.run_with_runtime(PROGRAM_ID_UNCHECKED_ARITHMETIC_0, &mut client);
 }


### PR DESCRIPTION
## Description

This PR introduces simple feature that allows users to initialize genesis of Fuzz Testing Environment with Account from base64 string. This is particularly helpful if you want to use some account dumped from the Mainnet where you can simply dump the Account and take the dumped content into the Fuzz Test Environment

## Related Tickets & Documents

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"