### PR TITLE
🔧 Allow empty AccountsSnapshots

### DIFF
--- a/crates/cli/src/command/init.rs
+++ b/crates/cli/src/command/init.rs
@@ -8,6 +8,7 @@ use crate::{_discover, show_howto};
 
 pub const ANCHOR_TOML: &str = "Anchor.toml";
 pub const TRIDENT_TOML: &str = "Trident.toml";
+pub const SKIP: &str = "\x1b[33mSkip\x1b[0m";
 
 #[throws]
 pub async fn init(force: bool) {
@@ -25,7 +26,7 @@ pub async fn init(force: bool) {
     } else {
         let root_path = Path::new(&root).join(TRIDENT_TOML);
         if root_path.exists() {
-            println!("It looks like Trident is already initialized as the Trident.toml was found in {} directory.",root);
+            println!("{SKIP} It looks like Trident is already initialized as the Trident.toml was found in {} directory.",root);
         } else {
             generator.initialize().await?;
         }


### PR DESCRIPTION
## Description

This PR introduces minor updates to allow derivation of AccountsSnapshots for empty Account Context. Currently, it was not possible to derive AccountsSnapshots for empty context as the unused lifetime error was triggered. This PR updates the source code generated by the AccountsSnapshots. In case no fields are present in the Account Context, the lifetime is preserved, however, the std::marker::PhantomData is used, which ensures consistency as the lifetime will be still present also for the empty implementation. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"