### PR TITLE
👷 Add purge docs cache CI

### DIFF
--- a/.github/workflows/purge-latest-docs.yaml
+++ b/.github/workflows/purge-latest-docs.yaml
@@ -1,0 +1,19 @@
+name: Purge latest docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  purge-latest-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Purge latest docs
+        run: ./purge_cache.sh
+        env:
+          DOMAIN_ZONE_ID: ${{ secrets.DOMAIN_ZONE_ID }}
+          DOMAIN_TOKEN: ${{ secrets.DOMAIN_TOKEN }}

--- a/purge_cache.sh
+++ b/purge_cache.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [[ -z "${DOMAIN_ZONE_ID}" ]]; then
+    echo -e "\033[0;31mERROR: Variable DOMAIN_ZONE_ID is missing, set it up in CI settings.\033[0m" >&2
+    exit 1
+fi
+
+if [[ -z "${DOMAIN_TOKEN}" ]]; then
+    echo -e "\033[0;31mERROR: Variable DOMAIN_KEY and DOMAIN_TOKEN are missing, set one of it in CI settings.\033[0m" >&2
+    exit 1
+fi
+
+SITEMAP_URL="https://ackee.xyz/trident/docs/latest/sitemap.xml"
+PURGE_URLS=$(curl -s $SITEMAP_URL | grep -Eo '<loc>[^<]*' | cut -d '>' -f 2)
+
+PURGE_URLS+=" https://ackee.xyz/trident/docs/versions.json"
+PURGE_URLS+=" https://ackee.xyz/trident/docs/latest/search/search_index.json"
+
+for url in $PURGE_URLS
+do
+    echo "Purgin cache for ${url}"
+    RESPONSE=$(curl -X POST "https://api.cloudflare.com/client/v4/zones/${DOMAIN_ZONE_ID}/purge_cache" \
+         -H "Authorization: Bearer ${DOMAIN_TOKEN}" \
+         --data "{\"files\":[\"${url}\"]}")
+    SUCCESS=$(echo $RESPONSE | jq -r '.success')
+    if [[ "$SUCCESS" != "true" ]]; then
+        echo "Failed to purge $url. Response: $RESPONSE"
+        exit 1
+    fi
+done


### PR DESCRIPTION
## Description

Github action to purge CDN cache for Trident docs (`/latest` only)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"