### PR TITLE
✨ Add support for Clock Sysvar manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ incremented upon a breaking change and the patch version will be incremented for
 
 ## [dev] - Unreleased
 
+**Added**
+
+- add/ add support for Clock sysvar manipulations with the client(i.e. warp to slot/epoch and forward in time) ([217](https://github.com/Ackee-Blockchain/trident/pull/217))
 
 ## [0.8.0] - 2024-10-21
 

--- a/crates/fuzz/src/fuzz_client.rs
+++ b/crates/fuzz/src/fuzz_client.rs
@@ -13,6 +13,15 @@ use crate::error::*;
 
 /// A trait providing methods to read and write (manipulate) accounts
 pub trait FuzzClient {
+    /// Warp to specific epoch
+    fn warp_to_epoch(&mut self, warp_epoch: u64);
+
+    /// Warp to specific slot
+    fn warp_to_slot(&mut self, warp_slot: u64);
+
+    /// Forward in time by the desired number of seconds
+    fn forward_in_time(&mut self, seconds: i64) -> Result<(), FuzzClientError>;
+
     /// Create an empty account and add lamports to it
     fn set_account(&mut self, lamports: u64) -> Keypair;
 


### PR DESCRIPTION
## Description

This PR adds support to the client for manipulating the Clock Sysvar, specifically by warping to a desired slot, warping to a desired epoch, and advancing time by a specified number of seconds.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"