### PR TITLE
Add option to create fuzz tests with custom names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ incremented upon a breaking change and the patch version will be incremented for
 
 ## [dev] - Unreleased
 
+**Added**
+
+- allow custom test name specification in fuzz test creation with `--test-name` flag ([255](https://github.com/Ackee-Blockchain/trident/pull/255))
+
 ## [0.9.0] - 2025-01-15
 
 **Added**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,6 +3861,7 @@ dependencies = [
  "anyhow",
  "clap",
  "fehler",
+ "heck 0.4.1",
  "termimad",
  "tokio",
  "trident-client",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1" }
 anyhow = { version = "1" }
 fehler = { version = "1" }
 termimad = "0.30.0"
+heck = "0.4.0"

--- a/crates/cli/src/command/init.rs
+++ b/crates/cli/src/command/init.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::{bail, Error};
 use fehler::throws;
+use heck::ToSnakeCase;
 use trident_client::___private::TestGenerator;
 
 use crate::{_discover, show_howto};
@@ -11,7 +12,7 @@ pub const TRIDENT_TOML: &str = "Trident.toml";
 pub const SKIP: &str = "\x1b[33mSkip\x1b[0m";
 
 #[throws]
-pub async fn init(force: bool) {
+pub async fn init(force: bool, test_name: Option<String>) {
     // look for Anchor.toml
     let root = if let Some(r) = _discover(ANCHOR_TOML)? {
         r
@@ -21,8 +22,9 @@ pub async fn init(force: bool) {
 
     let mut generator: TestGenerator = TestGenerator::new_with_root(&root)?;
 
+    let test_name_snake = test_name.map(|name| name.to_snake_case());
     if force {
-        generator.initialize().await?;
+        generator.initialize(test_name_snake).await?;
         show_howto();
     } else {
         let root_path = Path::new(&root).join(TRIDENT_TOML);
@@ -34,7 +36,7 @@ pub async fn init(force: bool) {
                 root
             );
         } else {
-            generator.initialize().await?;
+            generator.initialize(test_name_snake).await?;
             show_howto();
         }
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -42,6 +42,14 @@ enum Command {
             help = "Force Trident initialization. Trident dependencies will be updated based on the version of Trident CLI."
         )]
         force: bool,
+        #[arg(
+            short,
+            long,
+            required = false,
+            help = "Name of the fuzz test to initialize.",
+            value_name = "NAME"
+        )]
+        test_name: Option<String>,
     },
     #[command(
         about = "Run fuzz subcommands.",
@@ -67,7 +75,7 @@ pub async fn start() {
     match cli.command {
         Command::How => command::howto()?,
         Command::Fuzz { subcmd } => command::fuzz(subcmd).await?,
-        Command::Init { force } => command::init(force).await?,
+        Command::Init { force, test_name } => command::init(force, test_name).await?,
         Command::Clean => command::clean().await?,
     }
 }

--- a/documentation/docs/examples/examples.md
+++ b/documentation/docs/examples/examples.md
@@ -14,7 +14,7 @@ hide:
 
     Hello World example with Trident.
 
-    [Hello World!](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/hello_world)
+    [Hello World!](https://github.com/Ackee-Blockchain/trident/tree/master/examples/hello_world)
 
 -   :octicons-bug-16:{ .lg .middle } __Possible vulnerabilities and bugs__
 
@@ -22,13 +22,13 @@ hide:
 
     Check the possible attack vectors and bugs that can be detected using Trident.
 
-    [Unchecked Arithmetic](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/unchecked-arithmetic-0)
+    [Unchecked Arithmetic](https://github.com/Ackee-Blockchain/trident/tree/master/examples/common_issues/unchecked-arithmetic-0)
 
-    [Incorrect Instruction Sequence](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/incorrect-ix-sequence-1)
+    [Incorrect Instruction Sequence](https://github.com/Ackee-Blockchain/trident/tree/master/examples/common_issues/incorrect-ix-sequence-1)
 
-    [Unauthorized Access](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/unauthorized-access-2)
+    [Unauthorized Access](https://github.com/Ackee-Blockchain/trident/tree/master/examples/common_issues/unauthorized-access-2)
 
-    [Incorrect Integer Arithmetic](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/incorrect-integer-arithmetic-3)
+    [Incorrect Integer Arithmetic](https://github.com/Ackee-Blockchain/trident/tree/master/examples/common_issues/incorrect-integer-arithmetic-3)
 
 -   :octicons-tools-24:{ .lg .middle } __Customize with Arbitrary__
 
@@ -36,10 +36,10 @@ hide:
 
     You can use Arbitrary crate to your advantage and limit or customize the data that are sent to the instructions.
 
-    [Custom Data Types](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/arbitrary-custom-types-4)
+    [Custom Data Types](https://github.com/Ackee-Blockchain/trident/tree/master/examples/common_issues/arbitrary-custom-types-4)
 
 
-    [Limiting Instructions Inputs](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/arbitrary-limit-inputs-5)
+    [Limiting Instructions Inputs](https://github.com/Ackee-Blockchain/trident/tree/master/examples/common_issues/arbitrary-limit-inputs-5)
 
 -   :material-call-made:{ .lg .middle } __Cross-Program Invocation__
 
@@ -47,9 +47,9 @@ hide:
 
     Trident supports Cross-Program Invocation, you can fuzz your programs and create NFTs at the same time.
 
-    [Simple CPI](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/simple-cpi-6)
+    [Simple CPI](https://github.com/Ackee-Blockchain/trident/tree/master/examples/cpi/simple-cpi-6)
 
-    [CPI with Metaplex Metadata Program](https://github.com/Ackee-Blockchain/trident/tree/master/examples/fuzz-tests/cpi-metaplex-7)
+    [CPI with Metaplex Metadata Program](https://github.com/Ackee-Blockchain/trident/tree/master/examples/cpi/cpi-metaplex-7)
 
 -   :material-google-analytics:{ .lg .middle } __Benchmarking__
 

--- a/documentation/docs/faq/faq.md
+++ b/documentation/docs/faq/faq.md
@@ -17,7 +17,7 @@ hide:
 
 ### My program Instruction contains custom type such as Struct or Enum on its input, but it does not derive Arbitrary.
 
-- In this case you need to specify same type in the Fuzz Test (with the same fields). And implement From Trait to convert to your type. Check [Custom Data Types](../features/arbitrary-data.md/#custom-data-types) or [Examples of Arbitrary](../examples/examples.md).
+- In this case you need to specify same type in the Fuzz Test (with the same fields). And implement From Trait to convert to your type. Check [Custom Data Types](../features/customize-ix-data.md) or [Examples of Arbitrary](../examples/examples.md).
 
 
 ### Is Trident open-source ?

--- a/documentation/docs/features/customize-ix-data.md
+++ b/documentation/docs/features/customize-ix-data.md
@@ -1,4 +1,4 @@
-# Costomize Instruction Data
+# Customize Instruction Data
 
 
 Trident allows you to customize instruction data.

--- a/documentation/docs/features/features.md
+++ b/documentation/docs/features/features.md
@@ -69,7 +69,7 @@ Trident contains multiple features to enhance the fuzzing experience and increas
 
     Customize Instruction data, for example, to use integers from specific range.
 
-    [__Customize Instruction Data__](./custom-ix-data.md)
+    [__Customize Instruction Data__](./customize-ix-data.md)
 
 -   :material-weight-lifter:{ .lg .middle } __Trident Manifest__
 

--- a/documentation/docs/features/fuzz-instructions.md
+++ b/documentation/docs/features/fuzz-instructions.md
@@ -82,7 +82,7 @@ fn get_data(
 }
 ```
 
-Additionally, you can limit the range of the data generated using the `Arbitrary` crate. Check [Arbitrary Data](./arbitrary-data.md).
+Additionally, you can limit the range of the data generated using the `Arbitrary` crate. Check [Arbitrary Data](./customize-ix-data.md).
 
 ## `get_accounts()`
 
@@ -92,7 +92,7 @@ There are three main functions to use within the `get_accounts()`:
 
 - [`get_or_create_account()`](./fuzz-instructions.md/#get_or_create_account)
 - [`get()`](./fuzz-instructions.md/#get)
-- [`set_custom()`](./fuzz-instructions.md/#set_custom)
+- [`set_account_custom()`](./fuzz-instructions.md/#set_account_custom)
 
 For additional methods, check [Account Storage Methods](./account-storages.md/#account-storage-methods).
 

--- a/documentation/docs/features/limitations.md
+++ b/documentation/docs/features/limitations.md
@@ -4,7 +4,7 @@ hide:
 ---
 
 
-# Current limitations
+# Current Limitations
 
 This section summarizes some known limitations in the current development stage. Further development will be focused on resolving these limitations.
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -2,6 +2,8 @@
 hide:
   - navigation
   - toc
+
+title: Trident
 ---
 
 <h1 style="font-size: 65px;">{{ config.site_name }}</h1>

--- a/documentation/docs/installation/installation.md
+++ b/documentation/docs/installation/installation.md
@@ -5,65 +5,62 @@ hide:
 
 # Installation
 
-!!! important
+!!! important "Prerequisites"
 
-    **Prerequisite**
+    Before proceeding, ensure you have installed:
 
-    It is expected that you have installed:
+    - [Rust](https://www.rust-lang.org/tools/install) (stable version)
+    - [Solana CLI](https://solana.com/docs/intro/installation)
+    - [Anchor](https://www.anchor-lang.com/docs/installation)
 
-    - Rust ([Install Rust](https://www.rust-lang.org/tools/install))
-    - Solana CLI ([Install Solana CLI](https://docs.solanalabs.com/cli/install))
-    - Anchor Framework ([Install Anchor](https://www.anchor-lang.com/docs/installation))
+  Check out [supported versions](#supported-versions) for version compatibility.
 
-    For supported versions check the [Supported Versions](#supported-versions)
+## Install system dependencies
 
-## Install System Dependencies
-
-Update your package list and install the required packages:
+Update your package list:
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y \
-    curl \
-    git \
-    build-essential \
-    pkg-config \
-    libssl-dev \
-    npm \
-    vim \
-    nano \
-    wget \
-    binutils-dev \
-    libunwind-dev \
-    lldb
+sudo apt update
+sudo apt upgrade
 ```
-
-## Install Hongfuzz
-
-Install honggfuzz and AFL
-
+Install the required packages:
 ```bash
-cargo install honggfuzz
-
+sudo apt install build-essential
+sudo apt-get install binutils-dev
+sudo apt-get install libunwind-dev
 ```
-```bash
-cargo install cargo-afl
-```
-
 
 ## Install Trident
 
 ```bash
 cargo install trident-cli
-
 ```
+
+You can also use the `version` flag to install a specific version:
+```bash
+cargo install trident-cli --version x.y.z
+```
+
+## Install Hongfuzz and AFL
+
+```bash
+cargo install honggfuzz
+cargo install cargo-afl
+```
+To install a specific version use the following commands:
+```bash
+cargo install honggfuzz --version x.y.z
+cargo install cargo-afl --version x.y.z
+```
+
+
 
 ## Supported versions
 
 | ***{{ config.site_name }} CLI*** | ***Anchor*** | ***Solana*** | ***Rust*** | ***Honggfuzz*** | ***AFL*** |
 |-:|-:|-:|-:|-:|-:|
 | :material-developer-board: ***`develop`*** | `>=0.29.0` | `>=1.17.3` | `nightly` | `0.5.56` | `0.15.11` |
-| :material-tag: ***`0.8.*`*** | `>=0.29.0` | `>=1.17.3` | `nightly` | `0.5.56` | - |
+| :material-tag: ***`0.9.0`*** | `>=0.29.0` | `>=1.17.3` | `nightly` | `0.5.56` | `0.15.11` |
 | :material-tag: ***`0.8.*`*** | `0.30.1` | `^1.17.4` | `nightly` | `0.5.56` | - |
 | :material-tag: ***`0.7.0`*** | `>=0.29.*` | `^1.17.4` | `nightly` | `0.5.56` | - |
 | :material-tag: ***`0.6.0`*** | `>=0.29.*` | `^1.17` | `nightly` | `0.5.55` | - |

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://ackee.xyz/trident/docs
 repo_url: https://github.com/Ackee-Blockchain/trident
 repo_name: Ackee-Blockchain/trident
 edit_uri: edit/master/docs
-site_description: Trident is a Rust-based testing framework providing several convenient developer tools for testing Solana programs written in Anchor.
+site_description: Rust-based Fuzzing framework for Solana programs to help you ship secure code.
 site_author: Ackee Blockchain Security
 
 
@@ -98,6 +98,7 @@ plugins:
       type: timeago
   - mike:
       canonical_version: latest
+  - social
 
 # https://squidfunk.github.io/mkdocs-material/customization/?h=extra+css#additional-css
 extra_css:

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -5,3 +5,5 @@ mkdocs-git-revision-date-localized-plugin
 mkdocs-awesome-pages-plugin
 mkdocs-material
 mkdocs-macros-plugin
+cairosvg
+Pillow


### PR DESCRIPTION
## Description

Users can now specify custom names during fuzz test creation using `--test-name` flag.

<!--
Write a description of your pull request.
-->

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"