### PR TITLE
Fix types.rs file generation

### DIFF
--- a/crates/client/tests/test_fuzz.rs
+++ b/crates/client/tests/test_fuzz.rs
@@ -50,8 +50,7 @@ async fn verify_instructions(template: &Template) {
     let generated_instructions = template.get_instructions();
 
     for (name, generated_content) in generated_instructions {
-        let expected_path =
-            construct_path(&format!("fuzz_template/instructions/{}.rs", name));
+        let expected_path = construct_path(&format!("fuzz_template/instructions/{}.rs", name));
         let expected_content = fs::read_to_string(&expected_path)?;
         let formatted_content = Commander::format_program_code_nightly(&generated_content).await?;
 
@@ -82,8 +81,7 @@ async fn verify_transactions(template: &Template) {
     let generated_transactions = template.get_transactions();
 
     for (name, generated_content) in generated_transactions {
-        let expected_path =
-            construct_path(&format!("fuzz_template/transactions/{}.rs", name));
+        let expected_path = construct_path(&format!("fuzz_template/transactions/{}.rs", name));
         let expected_content = fs::read_to_string(&expected_path)?;
         let formatted_content = Commander::format_program_code_nightly(&generated_content).await?;
 

--- a/crates/template/src/template_getters.rs
+++ b/crates/template/src/template_getters.rs
@@ -90,7 +90,7 @@ impl Template {
     }
     pub fn get_custom_types(&self) -> String {
         let custom_types = self.custom_types.clone();
-        let module_definition: syn::File = parse_quote! {
+        let common_header = quote::quote! {
             use borsh::{BorshDeserialize, BorshSerialize};
             use trident_fuzz::fuzzing::*;
 
@@ -98,8 +98,22 @@ impl Template {
             /// or invariant checks.
             ///
             /// You can create your own types here and use them in transactions and instructions.
+        };
 
-            #(#custom_types)*
+        let module_definition: syn::File = match custom_types.len() {
+            0 => parse_quote! {
+                #common_header
+
+                #[derive(Arbitrary, Debug, BorshDeserialize, BorshSerialize, Clone)]
+                pub struct ExampleType {
+                    example_data: u8,
+                }
+            },
+            _ => parse_quote! {
+                #common_header
+
+                #(#custom_types)*
+            },
         };
         module_definition.into_token_stream().to_string()
     }


### PR DESCRIPTION
## Description

<!--
Write a description of your pull request.
-->

The syntax of types.rs file is invalid when the program doesn't contain any custom account types.

FIX: Added a default example type when no custom types are present to ensure valid syntax and provide reference to users who may want to add custom types in the future.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"