### PR TITLE
🚀 TridentAccounts mutability and signer attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ incremented upon a breaking change and the patch version will be incremented for
 
 **Added**
 
+-Added additional attributes to TridentAccounts, mut and signer ([268](https://github.com/Ackee-Blockchain/trident/pull/268))
+
 **Removed**
 
 **Changed**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "afl"
-version = "0.15.14"
+version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe38b594cedcc69d8d58022f17a98438e9a2b18c9028a0c3db4bc706f32ab8e7"
+checksum = "92ab76b4a49c1d3dcd5032a3c365670838db36b3154716046d57a4a3ce4298ec"
 dependencies = [
  "home",
  "libc",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -400,6 +400,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "digest 0.10.7",
+ "memmap2 0.9.5",
 ]
 
 [[package]]
@@ -689,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -699,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1210,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -3008,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -3635,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4009,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "trident-idl-spec"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2276a1dfa5c44b1fc0807e2e70717b2b5142ba5e4fbd71f44010424b9365bfdf"
+checksum = "bcc043200735bc6319ef80ad9bf3ec3bcbfec465946f0c68377958683ea2297b"
 dependencies = [
  "quote",
  "serde",
@@ -4086,9 +4087,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -17,7 +17,7 @@ trident-template = { path = "../template", version = "0.0.1" }
 
 
 # Trident IDL spec
-trident-idl-spec = "0.0.1"
+trident-idl-spec = "0.0.2"
 
 # Misc
 tokio = { version = "1", features = ["full"] }

--- a/crates/client/tests/fuzz_template/instructions/process_custom_types.rs
+++ b/crates/client/tests/fuzz_template/instructions/process_custom_types.rs
@@ -13,47 +13,50 @@ pub struct ProcessCustomTypesInstruction {
 /// Instruction Accounts
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct ProcessCustomTypesInstructionAccounts {
-    pub composite_account_nested: CompositeAccountNestedAccounts,
-    pub signer: TridentAccount,
-    pub data_account_1: TridentAccount,
-    pub data_account_2: TridentAccount,
-    pub data_account_3: TridentAccount,
-    pub data_account_4: TridentAccount,
-    pub data_account_5: TridentAccount,
-    pub data_account_6: TridentAccount,
-    pub composite_account: CompositeAccountAccounts,
+    composite_account_nested: CompositeAccountNestedAccounts,
+    #[account(signer)]
+    signer: TridentAccount,
+    data_account_1: TridentAccount,
+    data_account_2: TridentAccount,
+    data_account_3: TridentAccount,
+    data_account_4: TridentAccount,
+    data_account_5: TridentAccount,
+    data_account_6: TridentAccount,
+    composite_account: CompositeAccountAccounts,
 }
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct NestedInnerAccounts {
-    pub some_account: TridentAccount,
-    pub system_program: TridentAccount,
+    some_account: TridentAccount,
+    #[account(address = "11111111111111111111111111111111")]
+    system_program: TridentAccount,
 }
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct CompositeAccountNestedAccounts {
-    pub some_account: TridentAccount,
-    pub nested_inner: NestedInnerAccounts,
+    some_account: TridentAccount,
+    nested_inner: NestedInnerAccounts,
 }
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct CompositeAccountAccounts {
-    pub some_account: TridentAccount,
-    pub signer: TridentAccount,
-    pub data_account_1: TridentAccount,
+    some_account: TridentAccount,
+    #[account(signer)]
+    signer: TridentAccount,
+    data_account_1: TridentAccount,
 }
 /// Instruction Data
 #[derive(Arbitrary, Debug, BorshDeserialize, BorshSerialize, Clone)]
 pub struct ProcessCustomTypesInstructionData {
-    pub _input_classic: ClassicStruct,
-    pub _input_optional: OptionalFields,
-    pub _input_tuple: TupleStruct,
-    pub _input_enum: SimpleEnum,
-    pub _input_data_enum: DataEnum,
-    pub _input_multi_data_enum: MultiDataEnum,
-    pub _input_named_fields_enum: NamedFieldsEnum,
-    pub _input_generic_enum: GenericEnum,
-    pub _input_unit_variants: UnitVariants,
-    pub _input_nested: NestedStruct,
-    pub _input_default: DefaultStruct,
-    pub _input_generic_struct: GenericStruct,
+    _input_classic: ClassicStruct,
+    _input_optional: OptionalFields,
+    _input_tuple: TupleStruct,
+    _input_enum: SimpleEnum,
+    _input_data_enum: DataEnum,
+    _input_multi_data_enum: MultiDataEnum,
+    _input_named_fields_enum: NamedFieldsEnum,
+    _input_generic_enum: GenericEnum,
+    _input_unit_variants: UnitVariants,
+    _input_nested: NestedStruct,
+    _input_default: DefaultStruct,
+    _input_generic_struct: GenericStruct,
 }
 /// Implementation of instruction setters for fuzzing
 ///

--- a/crates/client/tests/fuzz_template/instructions/process_rust_types.rs
+++ b/crates/client/tests/fuzz_template/instructions/process_rust_types.rs
@@ -13,50 +13,53 @@ pub struct ProcessRustTypesInstruction {
 /// Instruction Accounts
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct ProcessRustTypesInstructionAccounts {
-    pub composite_account_nested: CompositeAccountNestedAccounts,
-    pub signer: TridentAccount,
-    pub data_account_1: TridentAccount,
-    pub data_account_2: TridentAccount,
-    pub data_account_3: TridentAccount,
-    pub data_account_4: TridentAccount,
-    pub data_account_5: TridentAccount,
-    pub data_account_6: TridentAccount,
-    pub composite_account: CompositeAccountAccounts,
+    composite_account_nested: CompositeAccountNestedAccounts,
+    #[account(signer)]
+    signer: TridentAccount,
+    data_account_1: TridentAccount,
+    data_account_2: TridentAccount,
+    data_account_3: TridentAccount,
+    data_account_4: TridentAccount,
+    data_account_5: TridentAccount,
+    data_account_6: TridentAccount,
+    composite_account: CompositeAccountAccounts,
 }
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct NestedInnerAccounts {
-    pub some_account: TridentAccount,
-    pub system_program: TridentAccount,
+    some_account: TridentAccount,
+    #[account(address = "11111111111111111111111111111111")]
+    system_program: TridentAccount,
 }
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct CompositeAccountNestedAccounts {
-    pub some_account: TridentAccount,
-    pub nested_inner: NestedInnerAccounts,
+    some_account: TridentAccount,
+    nested_inner: NestedInnerAccounts,
 }
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct CompositeAccountAccounts {
-    pub some_account: TridentAccount,
-    pub signer: TridentAccount,
-    pub data_account_1: TridentAccount,
+    some_account: TridentAccount,
+    #[account(signer)]
+    signer: TridentAccount,
+    data_account_1: TridentAccount,
 }
 /// Instruction Data
 #[derive(Arbitrary, Debug, BorshDeserialize, BorshSerialize, Clone)]
 pub struct ProcessRustTypesInstructionData {
-    pub _input_u8: u8,
-    pub _input_u16: u16,
-    pub _input_u32: u32,
-    pub _input_u64: u64,
-    pub _input_i8: i8,
-    pub _input_i16: i16,
-    pub _input_i32: i32,
-    pub _input_i64: i64,
-    pub _input_i128: i128,
-    pub _input_f32: f32,
-    pub _input_f64: f64,
-    pub _input_string: String,
-    pub _input_vec: Vec<u8>,
-    pub _input_vec_string: Vec<String>,
-    pub _input_bool: bool,
+    _input_u8: u8,
+    _input_u16: u16,
+    _input_u32: u32,
+    _input_u64: u64,
+    _input_i8: i8,
+    _input_i16: i16,
+    _input_i32: i32,
+    _input_i64: i64,
+    _input_i128: i128,
+    _input_f32: f32,
+    _input_f64: f64,
+    _input_string: String,
+    _input_vec: Vec<u8>,
+    _input_vec_string: Vec<String>,
+    _input_bool: bool,
 }
 /// Implementation of instruction setters for fuzzing
 ///

--- a/crates/fuzz/src/trident_accounts.rs
+++ b/crates/fuzz/src/trident_accounts.rs
@@ -89,6 +89,21 @@ impl TridentAccount {
             None => panic!("Snapshot after is not set"),
         }
     }
+    pub fn set_is_signer(&mut self) {
+        match &mut self.account_meta {
+            Some(account_meta) => account_meta.is_signer = true,
+            None => panic!("Account meta is not set"),
+        }
+    }
+    pub fn set_is_writable(&mut self) {
+        match &mut self.account_meta {
+            Some(account_meta) => account_meta.is_writable = true,
+            None => panic!("Account meta is not set"),
+        }
+    }
+    pub fn set_address(&mut self, address: Pubkey) {
+        self.account_meta = Some(AccountMeta::new_readonly(address, false));
+    }
 }
 
 /// A struct that represents an account in the snapshot.

--- a/crates/template/Cargo.toml
+++ b/crates/template/Cargo.toml
@@ -9,7 +9,7 @@ description = "The trident template crate is dedicated to generated Trident fuzz
 [dependencies]
 
 # Trident IDL spec
-trident-idl-spec = "0.0.1"
+trident-idl-spec = "0.0.2"
 
 # Misc
 syn = { version = "2", features = ["visit", "full"] }

--- a/examples/common_issues/arbitrary-limit-inputs-5/trident-tests/fuzz_0/instructions/init_vesting.rs
+++ b/examples/common_issues/arbitrary-limit-inputs-5/trident-tests/fuzz_0/instructions/init_vesting.rs
@@ -17,11 +17,9 @@ pub struct InitVestingInstructionAccounts {
     pub escrow: TridentAccount,
     pub escrow_token_account: TridentAccount,
     pub mint: TridentAccount,
-    #[skip_snapshot]
-    #[address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")]
+    #[account(address = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", skip_snapshot)]
     pub token_program: TridentAccount,
-    #[skip_snapshot]
-    #[address("11111111111111111111111111111111")]
+    #[account(address = "11111111111111111111111111111111", skip_snapshot)]
     pub system_program: TridentAccount,
 }
 /// Instruction Data

--- a/examples/common_issues/arbitrary-limit-inputs-5/trident-tests/fuzz_0/instructions/withdraw_unlocked.rs
+++ b/examples/common_issues/arbitrary-limit-inputs-5/trident-tests/fuzz_0/instructions/withdraw_unlocked.rs
@@ -18,11 +18,9 @@ pub struct WithdrawUnlockedInstructionAccounts {
     pub escrow_token_account: TridentAccount,
     pub escrow_pda_authority: TridentAccount,
     pub mint: TridentAccount,
-    #[skip_snapshot]
-    #[address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")]
+    #[account(address = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", skip_snapshot)]
     pub token_program: TridentAccount,
-    #[skip_snapshot]
-    #[address("11111111111111111111111111111111")]
+    #[account(address = "11111111111111111111111111111111", skip_snapshot)]
     pub system_program: TridentAccount,
 }
 /// Instruction Data

--- a/examples/cpi/cpi-metaplex-7/trident-tests/fuzz_0/instructions/initialize.rs
+++ b/examples/cpi/cpi-metaplex-7/trident-tests/fuzz_0/instructions/initialize.rs
@@ -15,14 +15,11 @@ pub struct InitializeInstructionAccounts {
     pub signer: TridentAccount,
     pub mint: TridentAccount,
     pub metadata_account: TridentAccount,
-    #[skip_snapshot]
-    #[address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s")]
+    #[account(address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s", skip_snapshot)]
     pub mpl_token_metadata: TridentAccount,
-    #[skip_snapshot]
-    #[address("11111111111111111111111111111111")]
+    #[account(address = "11111111111111111111111111111111", skip_snapshot)]
     pub system_program: TridentAccount,
-    #[skip_snapshot]
-    #[address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")]
+    #[account(address = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", skip_snapshot)]
     pub token_program: TridentAccount,
 }
 /// Instruction Data

--- a/examples/cpi/simple-cpi-6/trident-tests/fuzz_0/instructions/initialize_caller.rs
+++ b/examples/cpi/simple-cpi-6/trident-tests/fuzz_0/instructions/initialize_caller.rs
@@ -13,7 +13,7 @@ pub struct InitializeCallerInstruction {
 #[derive(Arbitrary, Debug, Clone, TridentAccounts)]
 pub struct InitializeCallerInstructionAccounts {
     pub signer: TridentAccount,
-    #[address("HJR1TK8bgrUWzysdpS1pBGBYKF7zi1tU9cS4qj8BW8ZL")]
+    #[account(address = "HJR1TK8bgrUWzysdpS1pBGBYKF7zi1tU9cS4qj8BW8ZL")]
     pub program: TridentAccount,
 }
 /// Instruction Data


### PR DESCRIPTION
## Description

This PR adds the ability to specify accounts as `mut` and `signer` within instruction accounts, additionally based on the IDL these flags are automatically derived when the template is created. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"