### PR TITLE
Add option to select which program to fuzz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ incremented upon a breaking change and the patch version will be incremented for
 
 -Added additional attributes to TridentAccounts, mut and signer ([268](https://github.com/Ackee-Blockchain/trident/pull/268))
 
+- Users can now specify a program for which they want to add or initialize a fuzz test using `--program-name` flag ([273](https://github.com/Ackee-Blockchain/trident/pull/273))
+
 **Removed**
 
 **Changed**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "fehler",
+ "heck 0.4.1",
  "pathdiff",
  "pretty_assertions",
  "rand 0.8.5",

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -14,7 +14,16 @@ pub const TRIDENT_TOML: &str = "Trident.toml";
 #[allow(non_camel_case_types)]
 pub enum FuzzCommand {
     #[command(about = "Generate new Fuzz Test template.")]
-    Add,
+    Add {
+        #[arg(
+            short,
+            long,
+            required = false,
+            help = "Specify the name of the program for which the fuzz test will be generated.",
+            value_name = "FILE"
+        )]
+        program_name: Option<String>,
+    },
     #[command(
         about = "Run the AFL on desired fuzz test.",
         override_usage = "Specify the desired fuzz \x1b[92m<TARGET>\x1b[0m.\
@@ -134,9 +143,9 @@ pub async fn fuzz(subcmd: FuzzCommand) {
             commander.run_hfuzz_debug(target, crash_file_path).await?;
         }
 
-        FuzzCommand::Add => {
+        FuzzCommand::Add { program_name } => {
             let mut generator = TestGenerator::new_with_root(&root)?;
-            generator.add_fuzz_test().await?;
+            generator.add_fuzz_test(program_name).await?;
             show_howto();
         }
     };

--- a/crates/cli/src/command/init.rs
+++ b/crates/cli/src/command/init.rs
@@ -11,7 +11,7 @@ pub const TRIDENT_TOML: &str = "Trident.toml";
 pub const SKIP: &str = "\x1b[33mSkip\x1b[0m";
 
 #[throws]
-pub async fn init(force: bool) {
+pub async fn init(force: bool, program_name: Option<String>) {
     // look for Anchor.toml
     let root = if let Some(r) = _discover(ANCHOR_TOML)? {
         r
@@ -22,7 +22,7 @@ pub async fn init(force: bool) {
     let mut generator: TestGenerator = TestGenerator::new_with_root(&root)?;
 
     if force {
-        generator.initialize().await?;
+        generator.initialize(program_name).await?;
         show_howto();
     } else {
         let root_path = Path::new(&root).join(TRIDENT_TOML);
@@ -34,7 +34,7 @@ pub async fn init(force: bool) {
                 root
             );
         } else {
-            generator.initialize().await?;
+            generator.initialize(program_name).await?;
             show_howto();
         }
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -42,6 +42,14 @@ enum Command {
             help = "Force Trident initialization. Trident dependencies will be updated based on the version of Trident CLI."
         )]
         force: bool,
+        #[arg(
+            short,
+            long,
+            required = false,
+            help = "Specify the name of the program for which fuzz test will be generated.",
+            value_name = "FILE"
+        )]
+        program_name: Option<String>,
     },
     #[command(
         about = "Run fuzz subcommands.",
@@ -67,7 +75,10 @@ pub async fn start() {
     match cli.command {
         Command::How => command::howto()?,
         Command::Fuzz { subcmd } => command::fuzz(subcmd).await?,
-        Command::Init { force } => command::init(force).await?,
+        Command::Init {
+            force,
+            program_name,
+        } => command::init(force, program_name).await?,
         Command::Clean => command::clean().await?,
     }
 }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -30,6 +30,7 @@ cargo_metadata = "0.18"
 toml = { version = "0.8", features = ["preserve_order"] }
 pathdiff = "0.2"
 rand = "0.8"
+heck = "0.4.0"
 
 [dev-dependencies]
 pretty_assertions = "1.1.0"

--- a/crates/client/src/commander/mod.rs
+++ b/crates/client/src/commander/mod.rs
@@ -58,13 +58,15 @@ impl Commander {
     }
 
     #[throws]
-    pub async fn build_anchor_project() {
-        let success = Command::new("anchor")
-            .arg("build")
-            .spawn()?
-            .wait()
-            .await?
-            .success();
+    pub async fn build_anchor_project(program_name: Option<String>) {
+        let mut cmd = Command::new("anchor");
+        cmd.arg("build");
+
+        if let Some(name) = program_name {
+            cmd.args(["-p", name.as_str()]);
+        }
+
+        let success = cmd.spawn()?.wait().await?.success();
         if !success {
             throw!(Error::BuildProgramsFailed);
         }

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -58,11 +58,11 @@ impl TestGenerator {
         }
     }
     #[throws]
-    pub async fn initialize(&mut self) {
-        Commander::build_anchor_project().await?;
+    pub async fn initialize(&mut self, program_name: Option<String>) {
+        Commander::build_anchor_project(program_name.clone()).await?;
 
-        self.get_program_packages().await?;
-        self.load_programs_idl()?;
+        self.get_program_packages(program_name.clone()).await?;
+        self.load_programs_idl(program_name.clone())?;
         self.create_template().await?;
         self.add_new_fuzz_test().await?;
         self.create_trident_toml().await?;
@@ -72,11 +72,11 @@ impl TestGenerator {
     }
 
     #[throws]
-    pub async fn add_fuzz_test(&mut self) {
-        Commander::build_anchor_project().await?;
+    pub async fn add_fuzz_test(&mut self, program_name: Option<String>) {
+        Commander::build_anchor_project(program_name.clone()).await?;
 
-        self.get_program_packages().await?;
-        self.load_programs_idl()?;
+        self.get_program_packages(program_name.clone()).await?;
+        self.load_programs_idl(program_name.clone())?;
         self.create_template().await?;
         self.add_new_fuzz_test().await?;
 
@@ -87,9 +87,9 @@ impl TestGenerator {
     }
 
     #[throws]
-    async fn get_program_packages(&mut self) {
+    async fn get_program_packages(&mut self, program_name: Option<String>) {
         // TODO consider optionally excluding packages
-        self.program_packages = collect_program_packages().await?;
+        self.program_packages = collect_program_packages(program_name).await?;
     }
 
     #[throws]
@@ -115,10 +115,10 @@ impl TestGenerator {
     }
 
     #[throws]
-    fn load_programs_idl(&mut self) {
+    fn load_programs_idl(&mut self, program_name: Option<String>) {
         let target_path = construct_path!(self.root, "target/idl/");
 
         // TODO consider optionally excluding packages
-        self.anchor_idls = crate::idl_loader::load_idls(target_path).unwrap();
+        self.anchor_idls = crate::idl_loader::load_idls(target_path, program_name).unwrap();
     }
 }

--- a/crates/client/src/utils.rs
+++ b/crates/client/src/utils.rs
@@ -72,27 +72,39 @@ pub fn get_fuzz_id(fuzz_dir_path: &Path) -> i32 {
     }
 }
 #[throws]
-pub async fn collect_program_packages() -> Vec<cargo_metadata::Package> {
-    let packages: Vec<cargo_metadata::Package> = program_packages().collect();
+pub async fn collect_program_packages(
+    program_name: Option<String>,
+) -> Vec<cargo_metadata::Package> {
+    let packages: Vec<cargo_metadata::Package> = program_packages(program_name).collect();
     if packages.is_empty() {
         throw!(Error::NoProgramsFound)
     } else {
         packages
     }
 }
-pub fn program_packages() -> impl Iterator<Item = cargo_metadata::Package> {
+pub fn program_packages(
+    program_name: Option<String>,
+) -> Box<dyn Iterator<Item = cargo_metadata::Package>> {
     let cargo_toml_data = cargo_metadata::MetadataCommand::new()
         .no_deps()
         .exec()
         .expect("Cargo.toml reading failed");
 
-    cargo_toml_data.packages.into_iter().filter(|package| {
-        // TODO less error-prone test if the package is a _program_?
-        if let Some("programs") = package.manifest_path.iter().nth_back(2) {
-            return true;
-        }
-        false
-    })
+    match program_name {
+        Some(name) => Box::new(
+            cargo_toml_data
+                .packages
+                .into_iter()
+                .filter(move |package| package.name == name),
+        ),
+        None => Box::new(cargo_toml_data.packages.into_iter().filter(|package| {
+            // TODO less error-prone test if the package is a _program_?
+            if let Some("programs") = package.manifest_path.iter().nth_back(2) {
+                return true;
+            }
+            false
+        })),
+    }
 }
 
 // #[throws]


### PR DESCRIPTION
## Description

Users can now specify the program for which the fuzz test will be created using an optional flag --program-name.

<!--
Write a description of your pull request.
-->

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"