### PR TITLE
Feat/custom test names new architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ incremented upon a breaking change and the patch version will be incremented for
 
 **Added**
 
--Added additional attributes to TridentAccounts, mut and signer ([268](https://github.com/Ackee-Blockchain/trident/pull/268))
+- Added additional attributes to TridentAccounts, mut and signer ([268](https://github.com/Ackee-Blockchain/trident/pull/268))
 
 - Users can now specify a program for which they want to add or initialize a fuzz test using `--program-name` flag ([273](https://github.com/Ackee-Blockchain/trident/pull/273))
+
+- Allow custom test name specification in fuzz test creation with `--test-name` flag ([274](https://github.com/Ackee-Blockchain/trident/pull/274))
 
 **Removed**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,6 +3876,7 @@ dependencies = [
  "anyhow",
  "clap",
  "fehler",
+ "heck 0.4.1",
  "termimad",
  "tokio",
  "trident-client",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1" }
 anyhow = { version = "1" }
 fehler = { version = "1" }
 termimad = "0.30.0"
+heck = "0.4.0"

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -153,7 +153,10 @@ pub async fn fuzz(subcmd: FuzzCommand) {
         } => {
             commander.run_hfuzz_debug(target, crash_file_path).await?;
         }
-        FuzzCommand::Add { program_name, test_name } => {
+        FuzzCommand::Add {
+            program_name,
+            test_name,
+        } => {
             let test_name_snake = test_name.map(|name| name.to_snake_case());
             if let Some(name) = &test_name_snake {
                 let fuzz_test_dir = Path::new(&root).join(TRIDENT_TESTS).join(name);
@@ -163,7 +166,9 @@ pub async fn fuzz(subcmd: FuzzCommand) {
                 }
             }
             let mut generator = TestGenerator::new_with_root(&root)?;
-            generator.add_fuzz_test(program_name, test_name_snake).await?;
+            generator
+                .add_fuzz_test(program_name, test_name_snake)
+                .await?;
             show_howto();
         }
     };

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -4,11 +4,14 @@ use anyhow::{bail, Error};
 
 use clap::Subcommand;
 use fehler::throws;
+use heck::ToSnakeCase;
 use trident_client::___private::{Commander, TestGenerator};
 
 use crate::{_discover, show_howto};
 
 pub const TRIDENT_TOML: &str = "Trident.toml";
+pub const TRIDENT_TESTS: &str = "trident-tests";
+pub const SKIP: &str = "\x1b[33mSkip\x1b[0m";
 
 #[derive(Subcommand)]
 #[allow(non_camel_case_types)]
@@ -23,6 +26,14 @@ pub enum FuzzCommand {
             value_name = "FILE"
         )]
         program_name: Option<String>,
+        #[arg(
+            short,
+            long,
+            required = false,
+            help = "Name of the fuzz test to add.",
+            value_name = "NAME"
+        )]
+        test_name: Option<String>,
     },
     #[command(
         about = "Run the AFL on desired fuzz test.",
@@ -142,10 +153,17 @@ pub async fn fuzz(subcmd: FuzzCommand) {
         } => {
             commander.run_hfuzz_debug(target, crash_file_path).await?;
         }
-
-        FuzzCommand::Add { program_name } => {
+        FuzzCommand::Add { program_name, test_name } => {
+            let test_name_snake = test_name.map(|name| name.to_snake_case());
+            if let Some(name) = &test_name_snake {
+                let fuzz_test_dir = Path::new(&root).join(TRIDENT_TESTS).join(name);
+                if fuzz_test_dir.exists() {
+                    println!("{SKIP} [{}/{}] already exists", TRIDENT_TESTS, name);
+                    return;
+                }
+            }
             let mut generator = TestGenerator::new_with_root(&root)?;
-            generator.add_fuzz_test(program_name).await?;
+            generator.add_fuzz_test(program_name, test_name_snake).await?;
             show_howto();
         }
     };

--- a/crates/cli/src/command/init.rs
+++ b/crates/cli/src/command/init.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::{bail, Error};
 use fehler::throws;
+use heck::ToSnakeCase;
 use trident_client::___private::TestGenerator;
 
 use crate::{_discover, show_howto};
@@ -11,7 +12,7 @@ pub const TRIDENT_TOML: &str = "Trident.toml";
 pub const SKIP: &str = "\x1b[33mSkip\x1b[0m";
 
 #[throws]
-pub async fn init(force: bool, program_name: Option<String>) {
+pub async fn init(force: bool, program_name: Option<String>, test_name: Option<String>) {
     // look for Anchor.toml
     let root = if let Some(r) = _discover(ANCHOR_TOML)? {
         r
@@ -21,8 +22,9 @@ pub async fn init(force: bool, program_name: Option<String>) {
 
     let mut generator: TestGenerator = TestGenerator::new_with_root(&root)?;
 
+    let test_name_snake = test_name.map(|name| name.to_snake_case());
     if force {
-        generator.initialize(program_name).await?;
+        generator.initialize(program_name, test_name_snake).await?;
         show_howto();
     } else {
         let root_path = Path::new(&root).join(TRIDENT_TOML);
@@ -34,7 +36,7 @@ pub async fn init(force: bool, program_name: Option<String>) {
                 root
             );
         } else {
-            generator.initialize(program_name).await?;
+            generator.initialize(program_name, test_name_snake).await?;
             show_howto();
         }
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -50,6 +50,14 @@ enum Command {
             value_name = "FILE"
         )]
         program_name: Option<String>,
+        #[arg(
+            short,
+            long,
+            required = false,
+            help = "Name of the fuzz test to initialize.",
+            value_name = "NAME"
+        )]
+        test_name: Option<String>,
     },
     #[command(
         about = "Run fuzz subcommands.",
@@ -78,7 +86,8 @@ pub async fn start() {
         Command::Init {
             force,
             program_name,
-        } => command::init(force, program_name).await?,
+            test_name
+        } => command::init(force, program_name, test_name).await?,
         Command::Clean => command::clean().await?,
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -86,7 +86,7 @@ pub async fn start() {
         Command::Init {
             force,
             program_name,
-            test_name
+            test_name,
         } => command::init(force, program_name, test_name).await?,
         Command::Clean => command::clean().await?,
     }

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -58,13 +58,13 @@ impl TestGenerator {
         }
     }
     #[throws]
-    pub async fn initialize(&mut self, program_name: Option<String>) {
+    pub async fn initialize(&mut self, program_name: Option<String>, test_name: Option<String>) {
         Commander::build_anchor_project(program_name.clone()).await?;
 
         self.get_program_packages(program_name.clone()).await?;
         self.load_programs_idl(program_name.clone())?;
         self.create_template().await?;
-        self.add_new_fuzz_test().await?;
+        self.add_new_fuzz_test(test_name).await?;
         self.create_trident_toml().await?;
 
         self.update_gitignore(CARGO_TARGET_DIR_DEFAULT_HFUZZ)?;
@@ -72,13 +72,13 @@ impl TestGenerator {
     }
 
     #[throws]
-    pub async fn add_fuzz_test(&mut self, program_name: Option<String>) {
+    pub async fn add_fuzz_test(&mut self, program_name: Option<String>, test_name: Option<String>) {
         Commander::build_anchor_project(program_name.clone()).await?;
 
         self.get_program_packages(program_name.clone()).await?;
         self.load_programs_idl(program_name.clone())?;
         self.create_template().await?;
-        self.add_new_fuzz_test().await?;
+        self.add_new_fuzz_test(test_name).await?;
 
         self.update_gitignore(CARGO_TARGET_DIR_DEFAULT_HFUZZ)?;
         self.update_gitignore(CARGO_TARGET_DIR_DEFAULT_AFL)?;

--- a/crates/client/src/test_generator_template.rs
+++ b/crates/client/src/test_generator_template.rs
@@ -93,12 +93,20 @@ impl TestGenerator {
     }
 
     #[throws]
-    pub(crate) async fn add_new_fuzz_test(&self) {
+    pub(crate) async fn add_new_fuzz_test(&self, test_name: Option<String>) {
         let trident_tests = construct_path!(self.root, TESTS_WORKSPACE_DIRECTORY);
 
-        let new_fuzz_test = format!("fuzz_{}", get_fuzz_id(&trident_tests)?);
+        let new_fuzz_test = match test_name {
+            Some(name) => name,
+            None => format!("fuzz_{}", get_fuzz_id(&trident_tests)?),
+        };
 
         let new_fuzz_test_dir = construct_path!(trident_tests, &new_fuzz_test);
+
+        if new_fuzz_test_dir.exists() {
+            println!("{SKIP} [{}] already exists", new_fuzz_test_dir.display());
+            return;
+        }
 
         self.create_instructions(&new_fuzz_test_dir).await?;
         self.create_transactions(&new_fuzz_test_dir).await?;


### PR DESCRIPTION
## Description

Users can now specify custom names during fuzz test creation using `--test-name` flag.

<!--
Write a description of your pull request.
-->

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"