### PR TITLE
✨ Add support for space, lamports and owner attributes to account macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ incremented upon a breaking change and the patch version will be incremented for
 
 **Added**
 
+- Add support for space, lamports and  owner to TridentAccounts macro ([320](https://github.com/Ackee-Blockchain/trident/pull/320))
 - Added support for simple fuzzing metrics for AFL ([309](https://github.com/Ackee-Blockchain/trident/pull/309))
 - Code coverage tracking support for both AFL and Honggfuzz fuzzing via the `-g, --generate-coverage` flag. Coverage data can be visualized using the VS Code extension (ADD_PR_NUMBER)
 

--- a/crates/syn/src/codegen/trident_accounts.rs
+++ b/crates/syn/src/codegen/trident_accounts.rs
@@ -77,16 +77,38 @@ impl ToTokens for TridentAccountsStruct {
                                 quote!(program_id)
                             };
 
+                            // Create AccountMetadata if space, owner, or lamports are specified
+                            let account_metadata = if f.constraints.space.is_some() || f.constraints.owner.is_some() || f.constraints.lamports.is_some() {
+                                let space = f.constraints.space.as_ref().map(|s| quote!(#s as usize)).unwrap_or_else(|| quote!(0));
+                                let owner = f.constraints.owner.as_ref().map(|o| quote!(#o)).unwrap_or_else(|| quote!(solana_sdk::system_program::ID));
+                                let lamports = f.constraints.lamports.as_ref().map(|l| quote!(#l)).unwrap_or_else(|| quote!(500 * solana_sdk::native_token::LAMPORTS_PER_SOL));
+
+                                quote!(Some(AccountMetadata::new(#lamports, #space, #owner)))
+                            } else {
+                                quote!(None)
+                            };
+
                             quote! {
                                 storage_accounts
                                     .#storage_ident
-                                    .get_or_create(self.#field_name.account_id, client, Some(PdaSeeds::new(&[#(#seeds),*], #program_id_to_use)), None)
+                                    .get_or_create(self.#field_name.account_id, client, Some(PdaSeeds::new(&[#(#seeds),*], #program_id_to_use)), #account_metadata)
                             }
                         } else {
+                            // Create AccountMetadata if space, owner, or lamports are specified
+                            let account_metadata = if f.constraints.space.is_some() || f.constraints.owner.is_some() || f.constraints.lamports.is_some() {
+                                let space = f.constraints.space.as_ref().map(|s| quote!(#s as usize)).unwrap_or_else(|| quote!(0));
+                                let owner = f.constraints.owner.as_ref().map(|o| quote!(#o)).unwrap_or_else(|| quote!(solana_sdk::system_program::ID));
+                                let lamports = f.constraints.lamports.as_ref().map(|l| quote!(#l)).unwrap_or_else(|| quote!(500 * solana_sdk::native_token::LAMPORTS_PER_SOL));
+
+                                quote!(Some(AccountMetadata::new(#lamports, #space, #owner)))
+                            } else {
+                                quote!(None)
+                            };
+
                             quote! {
                                 storage_accounts
                                     .#storage_ident
-                                    .get_or_create(self.#field_name.account_id, client, None, None)
+                                    .get_or_create(self.#field_name.account_id, client, None, #account_metadata)
                             }
                         };
 

--- a/crates/syn/src/parser/trident_accounts.rs
+++ b/crates/syn/src/parser/trident_accounts.rs
@@ -196,6 +196,30 @@ fn parse_constraints(attrs: &[Attribute]) -> ParseResult<TridentConstraints> {
                     }
                     Ok(())
                 }
+                "space" => {
+                    if meta.input.peek(syn::Token![=]) {
+                        meta.input.parse::<syn::Token![=]>()?;
+                        let expr: syn::Expr = meta.input.parse()?;
+                        constraints.space = Some(expr);
+                    }
+                    Ok(())
+                }
+                "owner" => {
+                    if meta.input.peek(syn::Token![=]) {
+                        meta.input.parse::<syn::Token![=]>()?;
+                        let expr: syn::Expr = meta.input.parse()?;
+                        constraints.owner = Some(expr);
+                    }
+                    Ok(())
+                }
+                "lamports" => {
+                    if meta.input.peek(syn::Token![=]) {
+                        meta.input.parse::<syn::Token![=]>()?;
+                        let expr: syn::Expr = meta.input.parse()?;
+                        constraints.lamports = Some(expr);
+                    }
+                    Ok(())
+                }
                 _ => Err(meta.error("unsupported constraint")),
             }
         })?;
@@ -208,6 +232,26 @@ fn parse_constraints(attrs: &[Attribute]) -> ParseResult<TridentConstraints> {
         return Err(ParseError::new(
             proc_macro2::Span::call_site(),
             "seeds require non-optional storage attribute",
+        ));
+    }
+
+    // Validate that owner is specified when space is used
+    if constraints.space.is_some() && constraints.owner.is_none() {
+        return Err(ParseError::new(
+            proc_macro2::Span::call_site(),
+            "space requires non-optional storage attribute",
+        ));
+    }
+
+    // Validate that space, owner, and lamports can only be used with storage
+    if (constraints.space.is_some()
+        || constraints.owner.is_some()
+        || constraints.lamports.is_some())
+        && constraints.storage.is_none()
+    {
+        return Err(ParseError::new(
+            proc_macro2::Span::call_site(),
+            "space, owner, and lamports attributes require non-optional storage attribute",
         ));
     }
 

--- a/crates/syn/src/parser/trident_accounts.rs
+++ b/crates/syn/src/parser/trident_accounts.rs
@@ -239,7 +239,7 @@ fn parse_constraints(attrs: &[Attribute]) -> ParseResult<TridentConstraints> {
     if constraints.space.is_some() && constraints.owner.is_none() {
         return Err(ParseError::new(
             proc_macro2::Span::call_site(),
-            "space requires non-optional storage attribute",
+            "space requires non-optional storage and owner attributes",
         ));
     }
 

--- a/crates/syn/src/types/trident_accounts.rs
+++ b/crates/syn/src/types/trident_accounts.rs
@@ -53,6 +53,9 @@ pub struct TridentConstraints {
     pub storage: Option<Ident>,
     pub seeds: Option<Vec<syn::Expr>>, // Store the raw expressions from the array
     pub program_id: Option<syn::Expr>,
+    pub space: Option<syn::Expr>,
+    pub owner: Option<syn::Expr>,
+    pub lamports: Option<syn::Expr>,
 }
 
 pub struct SeedDependency {

--- a/documentation/docs/trident-api-macro/trident-macros/trident-accounts.md
+++ b/documentation/docs/trident-api-macro/trident-macros/trident-accounts.md
@@ -211,7 +211,67 @@ pub struct ExampleAccounts {
     #[account(
         storage = custom_pda,
         seeds = [b"seed"],
-        program_id = pubkey!("11111111111111111111111111111111"))]
+        program_id = pubkey!("11111111111111111111111111111111")
+    )]
+    pub custom_pda: TridentAccount,
+}
+```
+
+
+---
+
+### `account(lamports)`
+
+Specifies the lamports for the account. If not provided, the default is 500 * LAMPORTS_PER_SOL.
+
+`This attribute is optional but requires the storage attribute`
+
+```rust
+#[derive(TridentAccounts)]
+pub struct ExampleAccounts {
+    #[account(
+        storage = custom_pda,
+        lamports = 5 * LAMPORTS_PER_SOL
+    )]
+    pub wallet: TridentAccount,
+}
+```
+
+---
+
+### `account(space)`
+
+Specifies the space for the account. If not provided, the default is 0.
+
+`This attribute is optional but requires the storage attribute and owner attribute`
+
+```rust
+#[derive(TridentAccounts)]
+pub struct ExampleAccounts {
+    #[account(
+        storage = custom_pda,
+        space = 8 + 100,
+        owner = pubkey!("program id goes here")
+    )]
+    pub custom_pda: TridentAccount,
+}
+```
+
+---
+
+### `account(owner)`
+
+Specifies the owner for the account. If not provided, the system program is default.
+
+`This attribute is optional but requires the storage attribute`
+
+```rust
+#[derive(TridentAccounts)]
+pub struct ExampleAccounts {
+    #[account(
+        storage = custom_pda,
+        owner = pubkey!("program id goes here")
+    )]
     pub custom_pda: TridentAccount,
 }
 ```

--- a/examples/hello_world/trident-tests/fuzz_0/instructions/initialize_fn.rs
+++ b/examples/hello_world/trident-tests/fuzz_0/instructions/initialize_fn.rs
@@ -18,6 +18,7 @@ pub struct InitializeFnInstructionAccounts {
     #[account(
         mut,
         storage = hello_world_account,
+        lamports = 5 * LAMPORTS_PER_SOL,
         seeds = [b"hello_world_seed"],
     )]
     pub hello_world_account: TridentAccount,


### PR DESCRIPTION
## Description

This PR aims to add support for lamports, space, and owner attributes to the account attribute macro used within fuzz test account contexts.

It will simplify the process of creating empty data accounts expected to be created before the initialization.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"