### PR TITLE
Expose SPL Token / Token-2022 IDs to avoid extra dependencies

### DIFF
--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -79,6 +79,14 @@ pub mod fuzzing {
     pub use reqwest;
     pub use tokio;
 
+    /// SPL Token Program ID
+    #[cfg(feature = "token")]
+    pub const SPL_TOKEN_ID: Pubkey = spl_token_interface::ID;
+
+    /// SPL Token-2022 Program ID
+    #[cfg(feature = "token")]
+    pub const SPL_TOKEN_2022_ID: Pubkey = spl_token_2022_interface::ID;
+
     #[cfg(feature = "token")]
     pub use super::trident::AccountExtension;
     #[cfg(feature = "token")]


### PR DESCRIPTION
This PR adds public constants for SPL Token program IDs behind the token feature flag:

SPL_TOKEN_ID — Program ID of the legacy SPL Token program

SPL_TOKEN_2022_ID — Program ID of the SPL Token-2022 program

Exposing these constants enables users to rely on the already included SPL interfaces, eliminating the need to import additional dependencies solely to access program IDs.